### PR TITLE
feature: Parameter Manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:livegain": "lerna run build --stream --scope livegain",
     "build:pingpongdelay": "lerna run build --stream --scope pingpongdelay",
     "build:sdk": "lerna run build --stream --scope sdk",
-    "build": "yarn build:sdk && yarn build:pingpongdelay && yarn build:livegain",
+    "build": "yarn build:sdk && yarn build:pingpongdelay",
     "start": "lerna run start --stream --scope host"
   },
   "workspaces": [

--- a/packages/host/src/main.js
+++ b/packages/host/src/main.js
@@ -43,6 +43,7 @@ const mountPlugin = (domNode) => {
 		{
 			params: { feedback: 0.7 },
 		});
+	window.instance = instance;
 	// instance.enable();
 
 	// Connect the audionode to the host

--- a/packages/host/src/main.js
+++ b/packages/host/src/main.js
@@ -41,9 +41,9 @@ const mountPlugin = (domNode) => {
 	// You can can optionnally give more options such as the initial state of the plugin
 	const instance = await Pingpongdelay.createInstance(audioContext,
 		{
-			initialState: { params: { feedback: .7 } }
+			params: { feedback: 0.7 },
 		});
-	instance.setState({ enabled: true });
+	instance.enable();
 
 	// Connect the audionode to the host
 	connectPlugin(instance.audioNode);
@@ -70,7 +70,7 @@ const mountPlugin = (domNode) => {
 		}, 5000);
 		setTimeout(() => {
 			console.log('timeout setParams');
-			instance.setParams({ feedback: .5 });
+			instance.setParams({ feedback: 0.5 });
 		}, 10000);
 	};
 })();

--- a/packages/host/src/main.js
+++ b/packages/host/src/main.js
@@ -55,6 +55,14 @@ const mountPlugin = (domNode) => {
 	mountPlugin(pluginDomNode);
 
 	player.onplay = () => {
+		let state;
+		setTimeout(() => {
+			// set param feedback after 5 seconds
+			instance.setParam('feedback', 0.5);
+			// store current state
+			state = instance.getState();
+			console.log('instance state', state);
+		}, 2500);
 		audioContext.resume(); // audio context must be resumed because browser restrictions
 		setTimeout(() => {
 			// Just for the example : updates the state of the plugin
@@ -69,8 +77,9 @@ const mountPlugin = (domNode) => {
 			}
 		}, 5000);
 		setTimeout(() => {
-			console.log('timeout setParams');
-			instance.setParams({ feedback: 0.5 });
+			// restore state to stored one
+			instance.setState(state); // feedback should go back to its initial value
+			console.log('instance state', instance.getState());
 		}, 10000);
 	};
 })();

--- a/packages/host/src/main.js
+++ b/packages/host/src/main.js
@@ -43,7 +43,7 @@ const mountPlugin = (domNode) => {
 		{
 			params: { feedback: 0.7 },
 		});
-	instance.enable();
+	// instance.enable();
 
 	// Connect the audionode to the host
 	connectPlugin(instance.audioNode);

--- a/packages/pingpongdelay/src/Gui/Gui.js
+++ b/packages/pingpongdelay/src/Gui/Gui.js
@@ -53,18 +53,18 @@ export default class PingPongDelayHTMLElement extends HTMLElement {
 			.querySelector('#knob1')
 			.addEventListener('input', (e) => {
 				// Using setParams
-				this.plugin.setParams({ feedback: e.target.value / 100 });
+				this.plugin.paramMgr.setParamTargetAtTime('feedback', e.target.value / 100, this.plugin.audioContext.currentTime, 0.01);
 			});
 		this.shadowRoot
 			.querySelector('#knob2')
 			.addEventListener('input', (e) => {
 				// Using setParam
-				this.plugin.setParam('time', e.target.value / 100);
+				this.plugin.paramMgr.setParamTargetAtTime('time', e.target.value / 100, this.plugin.audioContext.currentTime, 0.01);
 			});
 		this.shadowRoot
 			.querySelector('#knob3')
 			.addEventListener('input', (e) => {
-				this.plugin.setParams({ mix: e.target.value / 100 });
+				this.plugin.paramMgr.setParamTargetAtTime('mix', e.target.value / 100, this.plugin.audioContext.currentTime, 0.01);
 			});
 	}
 

--- a/packages/pingpongdelay/src/Gui/Gui.js
+++ b/packages/pingpongdelay/src/Gui/Gui.js
@@ -19,11 +19,11 @@ export default class PingPongDelayHTMLElement extends HTMLElement {
 		// MANDATORY for the GUI to observe the plugin state
 		this.plugin = plugin;
 		this.plugin.on('change:params', this.updateParams);
-		this.plugin.on('change:enabled', this.updateStatus);
+		this.plugin.on('change:enabled', this.updateEnabled);
 	}
 
-	updateStatus = (status) => {
-		this.shadowRoot.querySelector('#switch1').value = status;
+	updateEnabled = (enabled) => {
+		this.shadowRoot.querySelector('#switch1').value = enabled;
 	}
 
 	updateParams = (params) => {
@@ -44,20 +44,22 @@ export default class PingPongDelayHTMLElement extends HTMLElement {
 
 		this.setKnobs();
 		this.setSwitchListener();
-		this.updateStatus(this.plugin.state.enabled);
-		this.updateParams(this.plugin.state.params);
+		this.updateEnabled(this.plugin.enabled);
+		this.updateParams(this.plugin.params);
 	}
 
 	setKnobs() {
 		this.shadowRoot
 			.querySelector('#knob1')
 			.addEventListener('input', (e) => {
+				// Using setParams
 				this.plugin.setParams({ feedback: e.target.value / 100 });
 			});
 		this.shadowRoot
 			.querySelector('#knob2')
 			.addEventListener('input', (e) => {
-				this.plugin.setParams({ time: e.target.value / 100 });
+				// Using setParam
+				this.plugin.setParam('time', e.target.value / 100);
 			});
 		this.shadowRoot
 			.querySelector('#knob3')
@@ -67,10 +69,12 @@ export default class PingPongDelayHTMLElement extends HTMLElement {
 	}
 
 	setSwitchListener() {
+		const { plugin } = this;
 		this.shadowRoot
 			.querySelector('#switch1')
-			.addEventListener('change', () => {
-				this.plugin.setState({ enabled: !this.plugin.state.enabled });
+			.addEventListener('change', function onChange() {
+				if (this.checked) plugin.enable();
+				else plugin.disable();
 			});
 	}
 

--- a/packages/pingpongdelay/src/Gui/Gui.js
+++ b/packages/pingpongdelay/src/Gui/Gui.js
@@ -9,8 +9,12 @@ import template from './Gui.template.html';
 // MANDORY : the GUI should be a DOM node. WebComponents are
 // practical as they encapsulate everyhing in a shadow dom
 export default class PingPongDelayHTMLElement extends HTMLElement {
-	// plugin = the same that is passed in the DSP part. It's the instance
-	// of the class that extends WebAudioPlugin. It's an Observable plugin
+	/**
+	 * plugin = the same that is passed in the DSP part. It's the instance
+	 * of the class that extends WebAudioPlugin. It's an Observable plugin
+	 * @param {import("sdk").WebAudioPlugin<AudioNode, "feedback" | "time" | "mix">} plugin
+	 * @memberof PingPongDelayHTMLElement
+	 */
 	constructor(plugin) {
 		super();
 
@@ -18,23 +22,20 @@ export default class PingPongDelayHTMLElement extends HTMLElement {
 
 		// MANDATORY for the GUI to observe the plugin state
 		this.plugin = plugin;
-		this.plugin.on('change:params', this.updateParams);
-		this.plugin.on('change:enabled', this.updateEnabled);
 	}
 
-	updateEnabled = (enabled) => {
-		this.shadowRoot.querySelector('#switch1').value = enabled;
-	}
-
-	updateParams = (params) => {
+	handleAnimationFrame = () => {
 		const {
 			feedback,
 			mix,
 			time,
-		} = params;
+			enabled,
+		} = this.plugin.params;
 		this.shadowRoot.querySelector('#knob1').value = feedback * 100;
 		this.shadowRoot.querySelector('#knob2').value = time * 100;
 		this.shadowRoot.querySelector('#knob3').value = mix * 100;
+		this.shadowRoot.querySelector('#switch1').value = enabled;
+		window.requestAnimationFrame(this.handleAnimationFrame);
 	}
 
 	// Provided by the WebComponent API, called when the plugin is
@@ -44,8 +45,7 @@ export default class PingPongDelayHTMLElement extends HTMLElement {
 
 		this.setKnobs();
 		this.setSwitchListener();
-		this.updateEnabled(this.plugin.enabled);
-		this.updateParams(this.plugin.params);
+		window.requestAnimationFrame(this.handleAnimationFrame);
 	}
 
 	setKnobs() {

--- a/packages/pingpongdelay/src/Gui/Gui.js
+++ b/packages/pingpongdelay/src/Gui/Gui.js
@@ -52,19 +52,20 @@ export default class PingPongDelayHTMLElement extends HTMLElement {
 		this.shadowRoot
 			.querySelector('#knob1')
 			.addEventListener('input', (e) => {
-				// Using setParams
-				this.plugin.paramMgr.setParamTargetAtTime('feedback', e.target.value / 100, this.plugin.audioContext.currentTime, 0.01);
+				if (this.plugin.audioContext.state === 'suspended') this.plugin.paramMgr.setParamValue('feedback', e.target.value / 100);
+				else this.plugin.paramMgr.setParamTargetAtTime('feedback', e.target.value / 100, this.plugin.audioContext.currentTime, 0.01);
 			});
 		this.shadowRoot
 			.querySelector('#knob2')
 			.addEventListener('input', (e) => {
-				// Using setParam
-				this.plugin.paramMgr.setParamTargetAtTime('time', e.target.value / 100, this.plugin.audioContext.currentTime, 0.01);
+				if (this.plugin.audioContext.state === 'suspended') this.plugin.paramMgr.setParamValue('time', e.target.value / 100);
+				else this.plugin.paramMgr.setParamTargetAtTime('time', e.target.value / 100, this.plugin.audioContext.currentTime, 0.01);
 			});
 		this.shadowRoot
 			.querySelector('#knob3')
 			.addEventListener('input', (e) => {
-				this.plugin.paramMgr.setParamTargetAtTime('mix', e.target.value / 100, this.plugin.audioContext.currentTime, 0.01);
+				if (this.plugin.audioContext.state === 'suspended') this.plugin.paramMgr.setParamValue('mix', e.target.value / 100);
+				else this.plugin.paramMgr.setParamTargetAtTime('mix', e.target.value / 100, this.plugin.audioContext.currentTime, 0.01);
 			});
 	}
 

--- a/packages/pingpongdelay/src/Node.js
+++ b/packages/pingpongdelay/src/Node.js
@@ -50,36 +50,6 @@ export default class PingPongDelayNode extends CompositeAudioNode {
 		this.wetGainNode.connect(this._output);
 	}
 
-	// Setter part, it is here that you define the link between the params and the nodes values.
-	set time(_time) {
-		this.delayNodeLeft.delayTime.setValueAtTime(
-			_time,
-			this.context.currentTime,
-		);
-		this.delayNodeRight.delayTime.setValueAtTime(
-			_time,
-			this.context.currentTime,
-		);
-	}
-
-	set feedback(_feedback) {
-		this.feedbackGainNode.gain.setValueAtTime(
-			parseFloat(_feedback, 10),
-			this.context.currentTime,
-		);
-	}
-
-	set mix(_mix) {
-		this.dryGainNode.gain.setValueAtTime(
-			this.getDryLevel(_mix),
-			this.context.currentTime,
-		);
-		this.wetGainNode.gain.setValueAtTime(
-			this.getWetLevel(_mix),
-			this.context.currentTime,
-		);
-	}
-
 	isEnabled = true;
 
 	set status(_sig) {
@@ -94,23 +64,5 @@ export default class PingPongDelayNode extends CompositeAudioNode {
 			this._input.disconnect(this.dryGainNode);
 			this._input.connect(this._output);
 		}
-	}
-
-	// delay tools
-	// Tools to build sounds
-	isNumber(arg) {
-		return toString.call(arg) === '[object Number]' && arg === +arg;
-	}
-
-	getDryLevel(mix) {
-		if (!this.isNumber(mix) || mix > 1 || mix < 0) return 0;
-		if (mix <= 0.5) return 1;
-		return 1 - (mix - 0.5) * 2;
-	}
-
-	getWetLevel(mix) {
-		if (!this.isNumber(mix) || mix > 1 || mix < 0) return 0;
-		if (mix >= 0.5) return 1;
-		return 1 - (0.5 - mix) * 2;
 	}
 }

--- a/packages/pingpongdelay/src/descriptor.json
+++ b/packages/pingpongdelay/src/descriptor.json
@@ -2,19 +2,13 @@
 	"name": "PingPongDelay",
 	"params": {
 		"feedback": {
-			"defaultValue": 0.5,
-			"minValue": 0,
-			"maxValue": 1
+			"defaultValue": 0.5
 		},
 		"time": {
-			"defaultValue": 0.5,
-			"minValue": 0,
-			"maxValue": 1
+			"defaultValue": 0.5
 		},
 		"mix": {
-			"defaultValue": 0.5,
-			"minValue": 0,
-			"maxValue": 1
+			"defaultValue": 0.5
 		}
 	},
 	"banks": {

--- a/packages/pingpongdelay/src/index.js
+++ b/packages/pingpongdelay/src/index.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-underscore-dangle */
 // Double role for WebAudioPlugin :
 // 1 - Factory for providing the DSP/WebAudio node and GUI
 // 2 - This makes the instance of the current class an Observable
@@ -32,7 +31,7 @@ export default class PingPongDelayPlugin extends WebAudioPlugin {
 			dryGain: pingPongDelayNode.dryGainNode.gain,
 			wetGain: pingPongDelayNode.wetGainNode.gain,
 			feedback: pingPongDelayNode.feedbackGainNode.gain,
-			enabled: {},
+			enabled: { onChange: (value) => { pingPongDelayNode.status = !!value; } },
 		};
 		this.paramsMapping = {
 			time: {
@@ -50,13 +49,6 @@ export default class PingPongDelayPlugin extends WebAudioPlugin {
 				},
 			},
 		};
-
-		pingPongDelayNode.status = this.enabled;
-		// Listen to status change
-		// eslint-disable-next-line no-unused-vars
-		this.onEnabledChange((newEnabled, previousEnabled) => {
-			pingPongDelayNode.status = newEnabled;
-		});
 
 		return pingPongDelayNode;
 	}

--- a/packages/pingpongdelay/src/index.js
+++ b/packages/pingpongdelay/src/index.js
@@ -16,7 +16,7 @@ export default class PingPongDelayPlugin extends WebAudioPlugin {
 	async createAudioNode(options) {
 		const pingPongDelayNode = new PingPongDelayNode(this.audioContext, options);
 
-		pingPongDelayNode.status = this.status;
+		pingPongDelayNode.status = this.enabled;
 		pingPongDelayNode.feedback = this.params.feedback;
 		pingPongDelayNode.mix = this.params.mix;
 		pingPongDelayNode.time = this.params.time;

--- a/packages/pingpongdelay/src/index.js
+++ b/packages/pingpongdelay/src/index.js
@@ -16,22 +16,27 @@ export default class PingPongDelayPlugin extends WebAudioPlugin {
 	async createAudioNode(options) {
 		const pingPongDelayNode = new PingPongDelayNode(this.audioContext, options);
 
-		pingPongDelayNode.status = this.state.status;
-		pingPongDelayNode.feedback = this.state.params.feedback;
-		pingPongDelayNode.mix = this.state.params.mix;
-		pingPongDelayNode.time = this.state.params.time;
+		pingPongDelayNode.status = this.status;
+		pingPongDelayNode.feedback = this.params.feedback;
+		pingPongDelayNode.mix = this.params.mix;
+		pingPongDelayNode.time = this.params.time;
 
-		this.on('change:enabled', (status) => {
-			pingPongDelayNode.status = status;
+		// Listen to status change
+		// eslint-disable-next-line no-unused-vars
+		this.onEnabledChange((newEnabled, previousEnabled) => {
+			pingPongDelayNode.status = newEnabled;
 		});
 
-		this.on('change:params', (params) => {
-			const {
-				feedback,
-				mix,
-				time,
-			} = params;
-			pingPongDelayNode.feedback = feedback;
+		// Listen to a single param change
+		// eslint-disable-next-line no-unused-vars
+		this.onParamChange('feedback', (newFeedback, previousFeedback) => {
+			pingPongDelayNode.feedback = newFeedback;
+		});
+
+		// Listen to any param change
+		// eslint-disable-next-line no-unused-vars
+		this.onParamsChange((newParams, previousParams, changedParams) => {
+			const { mix, time } = newParams;
 			pingPongDelayNode.mix = mix;
 			pingPongDelayNode.time = time;
 		});

--- a/packages/pingpongdelay/src/index.js
+++ b/packages/pingpongdelay/src/index.js
@@ -22,14 +22,17 @@ export default class PingPongDelayPlugin extends WebAudioPlugin {
 	// The plugin redefines the async method createAudionode()
 	// that must return an <Audionode>
 	// It also listen to plugin state change event to update the audionode internal state
-	constructor(context) {
-		super(context);
+
+	async createAudioNode(options) {
+		const pingPongDelayNode = new PingPongDelayNode(this.audioContext, options);
+
 		this.internalParamsConfig = {
-			delayLeftTime: {},
-			delayRightTime: {},
-			dryGain: {},
-			wetGain: {},
-			feedback: {},
+			delayLeftTime: pingPongDelayNode.delayNodeLeft.delayTime,
+			delayRightTime: pingPongDelayNode.delayNodeRight.delayTime,
+			dryGain: pingPongDelayNode.dryGainNode.gain,
+			wetGain: pingPongDelayNode.wetGainNode.gain,
+			feedback: pingPongDelayNode.feedbackGainNode.gain,
+			enabled: {},
 		};
 		this.paramsMapping = {
 			time: {
@@ -47,21 +50,6 @@ export default class PingPongDelayPlugin extends WebAudioPlugin {
 				},
 			},
 		};
-	}
-
-	async createAudioNode(options) {
-		const pingPongDelayNode = new PingPongDelayNode(this.audioContext, options);
-
-		pingPongDelayNode.feedbackGainNode.gain.value = 0;
-		pingPongDelayNode.delayNodeLeft.delayTime.value = 0;
-		pingPongDelayNode.delayNodeRight.delayTime.value = 0;
-		pingPongDelayNode.dryGainNode.gain.value = 0;
-		pingPongDelayNode.wetGainNode.gain.value = 0;
-		this.paramMgr.connectParam('feedback', pingPongDelayNode.feedbackGainNode.gain);
-		this.paramMgr.connectParam('delayLeftTime', pingPongDelayNode.delayNodeLeft.delayTime);
-		this.paramMgr.connectParam('delayRightTime', pingPongDelayNode.delayNodeRight.delayTime);
-		this.paramMgr.connectParam('dryGain', pingPongDelayNode.dryGainNode.gain);
-		this.paramMgr.connectParam('wetGain', pingPongDelayNode.wetGainNode.gain);
 
 		pingPongDelayNode.status = this.enabled;
 		// Listen to status change

--- a/packages/pingpongdelay/src/index.js
+++ b/packages/pingpongdelay/src/index.js
@@ -7,38 +7,67 @@
 import { WebAudioPlugin } from 'sdk';
 
 import PingPongDelayNode from './Node';
-
-// Definition of a new plugin
+/**
+ * @typedef {"feedback" | "time" | "mix"} Params
+ * @typedef {"feedback" | "delayLeftTime" | "delayRightTime"
+ * | "dryGain" | "wetGain" | "enabled"} InternalParams
+ */
+/**
+ * Definition of a new plugin
+ *
+ * @class PingPongDelayPlugin
+ * @extends {WebAudioPlugin<PingPongDelayNode, Params, InternalParams>}
+ */
 export default class PingPongDelayPlugin extends WebAudioPlugin {
 	// The plugin redefines the async method createAudionode()
 	// that must return an <Audionode>
 	// It also listen to plugin state change event to update the audionode internal state
+	constructor(context) {
+		super(context);
+		this.internalParamsConfig = {
+			delayLeftTime: {},
+			delayRightTime: {},
+			dryGain: {},
+			wetGain: {},
+			feedback: {},
+		};
+		this.paramsMapping = {
+			time: {
+				delayLeftTime: {},
+				delayRightTime: {},
+			},
+			mix: {
+				dryGain: {
+					sourceRange: [0.5, 1],
+					targetRange: [1, 0],
+				},
+				wetGain: {
+					sourceRange: [0, 0.5],
+					targetRange: [0, 1],
+				},
+			},
+		};
+	}
+
 	async createAudioNode(options) {
 		const pingPongDelayNode = new PingPongDelayNode(this.audioContext, options);
 
-		pingPongDelayNode.status = this.enabled;
-		pingPongDelayNode.feedback = this.params.feedback;
-		pingPongDelayNode.mix = this.params.mix;
-		pingPongDelayNode.time = this.params.time;
+		pingPongDelayNode.feedbackGainNode.gain.value = 0;
+		pingPongDelayNode.delayNodeLeft.delayTime.value = 0;
+		pingPongDelayNode.delayNodeRight.delayTime.value = 0;
+		pingPongDelayNode.dryGainNode.gain.value = 0;
+		pingPongDelayNode.wetGainNode.gain.value = 0;
+		this.paramMgr.connectParam('feedback', pingPongDelayNode.feedbackGainNode.gain);
+		this.paramMgr.connectParam('delayLeftTime', pingPongDelayNode.delayNodeLeft.delayTime);
+		this.paramMgr.connectParam('delayRightTime', pingPongDelayNode.delayNodeRight.delayTime);
+		this.paramMgr.connectParam('dryGain', pingPongDelayNode.dryGainNode.gain);
+		this.paramMgr.connectParam('wetGain', pingPongDelayNode.wetGainNode.gain);
 
+		pingPongDelayNode.status = this.enabled;
 		// Listen to status change
 		// eslint-disable-next-line no-unused-vars
 		this.onEnabledChange((newEnabled, previousEnabled) => {
 			pingPongDelayNode.status = newEnabled;
-		});
-
-		// Listen to a single param change
-		// eslint-disable-next-line no-unused-vars
-		this.onParamChange('feedback', (newFeedback, previousFeedback) => {
-			pingPongDelayNode.feedback = newFeedback;
-		});
-
-		// Listen to any param change
-		// eslint-disable-next-line no-unused-vars
-		this.onParamsChange((newParams, previousParams, changedParams) => {
-			const { mix, time } = newParams;
-			pingPongDelayNode.mix = mix;
-			pingPongDelayNode.time = time;
 		});
 
 		return pingPongDelayNode;

--- a/packages/sdk/src/Loader.d.ts
+++ b/packages/sdk/src/Loader.d.ts
@@ -1,4 +1,4 @@
-import WebAudioPlugin, { PluginDescriptor } from "./WebAudioPlugin";
+import WebAudioPlugin from "./WebAudioPlugin";
 
 export interface LoadPluginOptions {
     noGui: boolean;

--- a/packages/sdk/src/ParamMgr/AudioWorkletProcessor.d.ts
+++ b/packages/sdk/src/ParamMgr/AudioWorkletProcessor.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="types.d.ts" />
+
+export default AudioWorkletProcessor;

--- a/packages/sdk/src/ParamMgr/AudioWorkletRegister.d.ts
+++ b/packages/sdk/src/ParamMgr/AudioWorkletRegister.d.ts
@@ -1,18 +1,5 @@
+/// <reference path="types.d.ts" />
+
 export const registeredProcessors: Set<string>;
 export const registeringProcessors: Set<string>;
-declare class AudioWorkletRegister {
-    /**
-	 * Register a AudioWorklet processor in a closure,
-     * sending to AudioWorkletProcessor with an unique identifier
-     * avoiding double registration
-     *
-     * @param {string} processorId if duplicated, the processor will not be readded.
-     * @param {(id: string, ...injections: any[]) => void} processor a serializable function that contains an AudioWorkletProcessor
-     * with its registration in the AudioWorkletGlobalScope
-     * @param {AudioWorklet} audioWorklet AudioWorklet instance
-     * @param {...any[]} injection this will be serialized and injected to the `processor` function
-     * @returns {Promise<void>} a Promise<void>
-     */
-    static register(processorId: string, processor: (id: string, ...injections: any[]) => void, audioWorklet: AudioWorklet, ...injection: any[]): Promise<void>
-}
 export default AudioWorkletRegister;

--- a/packages/sdk/src/ParamMgr/AudioWorkletRegister.d.ts
+++ b/packages/sdk/src/ParamMgr/AudioWorkletRegister.d.ts
@@ -1,0 +1,18 @@
+export const registeredProcessors: Set<string>;
+export const registeringProcessors: Set<string>;
+declare class AudioWorkletRegister {
+    /**
+	 * Register a AudioWorklet processor in a closure,
+     * sending to AudioWorkletProcessor with an unique identifier
+     * avoiding double registration
+     *
+     * @param {string} processorId if duplicated, the processor will not be readded.
+     * @param {(id: string, ...injections: any[]) => void} processor a serializable function that contains an AudioWorkletProcessor
+     * with its registration in the AudioWorkletGlobalScope
+     * @param {AudioWorklet} audioWorklet AudioWorklet instance
+     * @param {...any[]} injection this will be serialized and injected to the `processor` function
+     * @returns {Promise<void>} a Promise<void>
+     */
+    static register(processorId: string, processor: (id: string, ...injections: any[]) => void, audioWorklet: AudioWorklet, ...injection: any[]): Promise<void>
+}
+export default AudioWorkletRegister;

--- a/packages/sdk/src/ParamMgr/AudioWorkletRegister.js
+++ b/packages/sdk/src/ParamMgr/AudioWorkletRegister.js
@@ -2,15 +2,6 @@ export const registeredProcessors = new Set();
 export const registeringProcessors = new Set();
 
 export default class AudioWorkletRegister {
-	/*
-	static processorID;
-
-	static processorURL;
-
-	static processor;
-
-	static Node;
-	*/
 	static registeredProcessors = registeredProcessors;
 
 	static registeringProcessors = registeringProcessors;
@@ -34,16 +25,6 @@ export default class AudioWorkletRegister {
 		this.resolves[processorId] = [];
 	}
 
-	/**
-	 * Register a processor with unique identifier
-	 *
-	 * @static
-	 * @param {string} processorId if duplicated, the processor will not be readded.
-	 * @param {AudioWorklet} audioWorklet AudioWorklet instance
-	 * @param {any[]} injection will be injected to the processor if possible
-	 * @returns {Promise<void>} a Promise<void>
-	 * @memberof AudioWorkletRegister
-	 */
 	static async register(processorId, processor, audioWorklet, ...injection) {
 		if (!this.resolves[processorId]) this.resolves[processorId] = [];
 		if (!this.rejects[processorId]) this.rejects[processorId] = [];

--- a/packages/sdk/src/ParamMgr/AudioWorkletRegister.js
+++ b/packages/sdk/src/ParamMgr/AudioWorkletRegister.js
@@ -1,0 +1,63 @@
+export const registeredProcessors = new Set();
+export const registeringProcessors = new Set();
+
+export default class AudioWorkletRegister {
+	/*
+	static processorID;
+
+	static processorURL;
+
+	static processor;
+
+	static Node;
+	*/
+	static registeredProcessors = registeredProcessors;
+
+	static registeringProcessors = registeringProcessors;
+
+	static resolves = {};
+
+	static rejects = {};
+
+	static async registerProcessor(processorId, processor, audioWorklet, ...injection) {
+		this.registeringProcessors.add(processorId);
+		try {
+			const url = window.URL.createObjectURL(new Blob([`(${processor.toString()})(${[processorId, ...injection].map(JSON.stringify).join(', ')});`], { type: 'text/javascript' }));
+			await audioWorklet.addModule(url);
+			this.resolves[processorId].forEach((f) => f());
+			this.registeringProcessors.delete(processorId);
+			this.registeredProcessors.add(processorId);
+		} catch (e) {
+			this.rejects[processorId].forEach((f) => f(e));
+		}
+		this.rejects[processorId] = [];
+		this.resolves[processorId] = [];
+	}
+
+	/**
+	 * Register a processor with unique identifier
+	 *
+	 * @static
+	 * @param {string} processorId if duplicated, the processor will not be readded.
+	 * @param {AudioWorklet} audioWorklet AudioWorklet instance
+	 * @param {any[]} injection will be injected to the processor if possible
+	 * @returns {Promise<void>} a Promise<void>
+	 * @memberof AudioWorkletRegister
+	 */
+	static async register(processorId, processor, audioWorklet, ...injection) {
+		if (!this.resolves[processorId]) this.resolves[processorId] = [];
+		if (!this.rejects[processorId]) this.rejects[processorId] = [];
+		const promise = new Promise((resolve, reject) => {
+			this.resolves[processorId].push(resolve);
+			this.rejects[processorId].push(reject);
+		});
+		const registered = this.registeredProcessors.has(processorId);
+		const registering = this.registeringProcessors.has(processorId);
+		if (registered) return Promise.resolve();
+		if (registering) return promise;
+		if (!registered && audioWorklet) {
+			this.registerProcessor(processorId, processor, audioWorklet, ...injection);
+		}
+		return promise;
+	}
+}

--- a/packages/sdk/src/ParamMgr/DisposableAudioWorkletNode.d.ts
+++ b/packages/sdk/src/ParamMgr/DisposableAudioWorkletNode.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="types.d.ts" />
+
+export default DisposableAudioWorkletNode;

--- a/packages/sdk/src/ParamMgr/DisposableAudioWorkletNode.js
+++ b/packages/sdk/src/ParamMgr/DisposableAudioWorkletNode.js
@@ -1,0 +1,14 @@
+export default class DisposableAudioWorkletNode extends AudioWorkletNode {
+	destroyed = false;
+
+	destroy() {
+		this.port.postMessage({ destroy: true });
+		this.port.close();
+		this.destroyed = true;
+	}
+
+	constructor(context, name, options) {
+		super(context, name, options);
+		this.options = options;
+	}
+}

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
@@ -1,6 +1,14 @@
 import DisposableAudioWorkletNode from "./DisposableAudioWorkletNode";
 import WebAudioPlugin from "../WebAudioPlugin";
 
+/**
+ * Parameter Manager Class
+ *
+ * @interface ParamMgrNode
+ * @extends {DisposableAudioWorkletNode}
+ * @template Params exposed parameters names
+ * @template InternalParams internal parameters names
+ */
 declare interface ParamMgrNode<
         Params extends string = string,
         InternalParams extends string = Params
@@ -10,29 +18,210 @@ declare interface ParamMgrNode<
         Params,
         { paramsConfig: ParametersDescriptor<Params>; paramsMapping: ParametersMapping<Params, InternalParams>; internalParams: InternalParams[]; instanceId: string; }
 > {
+    /**
+     * The `WebAudioPlugin` where this lives in, used to dispatch events.
+     *
+     * @type {WebAudioPlugin<any, Params, InternalParams>}
+     * @memberof ParamMgrNode
+     */
     plugin: WebAudioPlugin<any, Params, InternalParams>;
+    /**
+     * An array that contains ordered internal params names.
+     * The order is important for the output connections and for the parameters' values buffer
+     *
+     * @type {InternalParams[]}
+     * @memberof ParamMgrNode
+     */
     internalParams: InternalParams[];
+    /**
+     * The plugin's internal parameters description.
+     * Used for denormalize normalized exposed parameters values
+     *
+     * @type {InternalParametersDescriptor<InternalParams>}
+     * @memberof ParamMgrNode
+     */
     internalParamsConfig: InternalParametersDescriptor<InternalParams>;
+    /**
+     * The lock will be true if the `$paramsBuffer` is changing by the processor.
+     * This is a view of a `SharedArrayBuffer`
+     *
+     * @type {Int32Array}
+     * @memberof ParamMgrNode
+     */
     $lock: Int32Array;
+    /**
+     * The values of internal parameters,
+     * contains one value for each param,
+     * will be updated each `AudioWorklet` buffer.
+     * This is a view of a `SharedArrayBuffer`
+     *
+     * @type {Float32Array}
+     * @memberof ParamMgrNode
+     */
     $paramsBuffer: Float32Array;
+    /**
+     * Previous params value since last event dispatch of any
+     * non-AudioParam internal parameters
+     *
+     * @type {Float32Array}
+     * @memberof ParamMgrNode
+     */
     $prevParamsBuffer: Float32Array;
+    /**
+     * A set for internal parameters names.
+     * These params is ready for next change event dispatch.
+     * (to throttle event dispatch rate for the non-AudioParam internal parameters)
+     *
+     * @type {Set<InternalParams>}
+     * @memberof ParamMgrNode
+     */
     paramsChangeCanDispatch: Set<InternalParams>;
+    /**
+     * Event dispatch callbacks reference of the `setTimeout` calls.
+     * Used to clear the callbacks while destroying the plugin.
+     *
+     * @type {number[]}
+     * @memberof ParamMgrNode
+     */
     paramsUpdateCheckFnRef: number[];
+    /**
+     * waiting for the processor that gives the `paramsBuffer` `SharedArrayBuffer`
+     *
+     * @returns {Promise<ParamMgrNode>}
+     * @memberof ParamMgrNode
+     */
     initialize(): Promise<ParamMgrNode>;
+    /**
+     * Force to check if an internal param is updated to dispatch immediately value change event if necessary.
+     * Note that the event will also be throttled to the automation rate.
+     *
+     * @param {InternalParams} name
+     * @memberof ParamMgrNode
+     */
     requestDispatchIParamChange(name: InternalParams): void;
-    getIParamIndex(name: InternalParams): number;
+    /**
+     * get the output index of an internal parameter from its name,
+     * null if not exist
+     *
+     * @param {InternalParams} name
+     * @returns {number | null}
+     * @memberof ParamMgrNode
+     */
+    getIParamIndex(name: InternalParams): number | null;
+    /**
+     * connect an internal parameter audio output to an AudioParam or an AudioNode.
+     * Note that if the destination is declared in the `internalParamsConfig`,
+     * there is no need to reconnect it.
+     *
+     * @param {InternalParams} name
+     * @param {(AudioParam | AudioNode)} dest
+     * @param {number} [index]
+     * @memberof ParamMgrNode
+     */
     connectIParam(name: InternalParams, dest: AudioParam | AudioNode, index?: number): void;
+    /**
+     * disonnect an internal parameter audio output to an AudioParam or an AudioNode.
+     *
+     * @param {InternalParams} name
+     * @param {(AudioParam | AudioNode)} [dest]
+     * @param {number} [index]
+     * @memberof ParamMgrNode
+     */
     disconnectIParam(name: InternalParams, dest?: AudioParam | AudioNode, index?: number): void;
+    /**
+     * get the current value of an internal parameter
+     *
+     * @param {InternalParams} name
+     * @returns {number}
+     * @memberof ParamMgrNode
+     */
     getIParamValue(name: InternalParams): number;
+    /**
+     * get the current value of every internal parameters
+     *
+     * @returns {Record<InternalParams, number>}
+     * @memberof ParamMgrNode
+     */
     getIParamsValues(): Record<InternalParams, number>;
+    /**
+     * get the `AudioParam` instance of an exposed parameter
+     *
+     * @param {Params} name
+     * @returns {AudioParam}
+     * @memberof ParamMgrNode
+     */
     getParam(name: Params): AudioParam;
+    /**
+     * get the `AudioParam` instance of every exposed parameters
+     *
+     * @returns {Record<Params, AudioParam>}
+     * @memberof ParamMgrNode
+     */
     getParams(): Record<Params, AudioParam>;
+    /**
+     * get the current value of an exposed parameter,
+     * shorthand for `AudioParam.prototype.value`
+     *
+     * @param {Params} name
+     * @returns {number}
+     * @memberof ParamMgrNode
+     */
     getParamValue(name: Params): number;
+    /**
+     * get the current value of an exposed parameter,
+     * shorthand for `AudioParam.prototype.value = value`
+     *
+     * @param {Params} name
+     * @param {number} value
+     * @memberof ParamMgrNode
+     */
     setParamValue(name: Params, value: number): void;
+    /**
+     * get the current value of every exposed parameters
+     *
+     * @param {Params} name
+     * @param {number} value
+     * @memberof ParamMgrNode
+     */
     getParamsValues(): Record<Params, number>;
+    /**
+     * set the current value of every exposed parameters
+     *
+     * @param {Record<Params, number>} values
+     * @memberof ParamMgrNode
+     */
     setParamsValues(values: Record<Params, number>): void;
+    /**
+     * normalized value version of `getParamValue()`
+     *
+     * @param {Params} name
+     * @returns {number}
+     * @memberof ParamMgrNode
+     */
     getNormalizedParamValue(name: Params): number;
+    /**
+     * normalized value version of `setParamValue()`
+     *
+     * @param {Params} name
+     * @param {number} value
+     * @memberof ParamMgrNode
+     */
     setNormalizedParamValue(name: Params, value: number): void;
+    /**
+     * normalized value version of `getParamsValues()`
+     *
+     * @returns {Record<Params, number>}
+     * @memberof ParamMgrNode
+     */
+    getNormalizedParamsValues(): Record<Params, number>;
+    /**
+     * normalized value version of `setParamsValues()`
+     *
+     * @param {Record<Params, number>} values
+     * @memberof ParamMgrNode
+     */
+    setNormalizedParamsValues(values: Record<Params, number>): void;
+    // `AudioParam.prototype` methods with there normlized value version
     setParamValueAtTime(name: Params, value: number, startTime: number): AudioParam;
     setNormalizedParamValueAtTime(name: Params, value: number, startTime: number): AudioParam;
     linearRampToParamValueAtTime(name: Params, value: number, endTime: number): AudioParam;
@@ -45,15 +234,33 @@ declare interface ParamMgrNode<
     setNormalizedParamValueCurveAtTime(name: Params, values: Iterable<number> | number[] | Float32Array, startTime: number, duration: number): AudioParam;
     cancelScheduledParamValues(name: Params, cancelTime: number): AudioParam;
     cancelAndHoldParamAtTime(name: Params, cancelTime: number): AudioParam;
+    /**
+     * will be called while the plugin is destroying
+     *
+     * @memberof ParamMgrNode
+     */
     destroy(): void;
 }
 declare const ParamMgrNode: {
     prototype: AudioWorkletNode;
+	/**
+     * Creates an instance of ParamMgrNode.
+     *
+     * @param {BaseAudioContext} context AudioContext
+     * @param {string} processorId Processor identifier
+	 * @param {Record<Params, number>} parameterData parameters initial values map
+     * @param {{ paramsConfig: ParametersDescriptor<Params>; paramsMapping: ParametersMapping<Params, InternalParams>; internalParams: InternalParams[]; instanceId: string; }} processorOptions
+     * @param {WebAudioPlugin<any, Params, InternalParams>} plugin the plugin instance
+	 * @param {InternalParametersDescriptor<InternalParams>} internalParamsConfig
+     * @memberof ParamMgrNode
+     */
     new <Params extends string = string, InternalParams extends string = string>(
         context: BaseAudioContext,
         processorId: string,
         parameterData: Record<Params, number>,
-        processorOptions: { paramsConfig: ParametersDescriptor; paramsMapping: ParametersMapping; internalParamsConfig: InternalParametersDescriptor }
+        processorOptions: { paramsConfig: ParametersDescriptor<Params>; paramsMapping: ParametersMapping<Params, InternalParams>; internalParams: InternalParams[]; instanceId: string; },
+        plugin: WebAudioPlugin<any, Params, InternalParams>,
+        internalParamsConfig: InternalParametersDescriptor<InternalParams>
     ): ParamMgrNode<Params, InternalParams>;
 }
 export default ParamMgrNode;

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
@@ -1,0 +1,31 @@
+import DisposableAudioWorkletNode from "./DisposableAudioWorkletNode";
+
+declare interface ParamMgrNode<
+        Params extends string = string,
+        InternalParams extends string = string
+> extends DisposableAudioWorkletNode<
+        { buffer: { lock: Int32Array, paramsBuffer: Float32Array } },
+        { destroy: true, mapping: ParametersMapping, buffer: true },
+        Params,
+        { paramsConfig: ParametersDescriptor; mapping: ParametersMapping; internalParamsConfig: InternalParametersDescriptor }
+> {
+    internalParamsConfig: InternalParametersDescriptor<InternalParams>;
+    $lock: Int32Array;
+    $paramsBuffer: Float32Array;
+    init(): Promise<void>;
+    getParamIndex(key: InternalParams): number;
+    connectParam(key: InternalParams, dest: AudioParam | AudioNode, index?: number): void;
+    disconnectParam(key: InternalParams, dest?: AudioParam | AudioNode, index?: number): void;
+    getParamValue(key: InternalParams): number;
+    destroy(): void;
+}
+declare const ParamMgrNode: {
+    prototype: AudioWorkletNode;
+    new <InternalParams extends string = string>(
+        context: BaseAudioContext,
+        processorId: string,
+        parameterData: Record<Params, number>,
+        processorOptions: { paramsConfig: ParametersDescriptor; mapping: ParametersMapping; internalParamsConfig: InternalParametersDescriptor }
+    ): ParamMgrNode<InternalParams>;
+}
+export default ParamMgrNode;

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
@@ -92,6 +92,22 @@ declare interface ParamMgrNode<
      */
     initialize(): Promise<ParamMgrNode>;
     /**
+     * convert an WebAudio time stamp to frame index
+     *
+     * @param {number} time
+     * @returns {number}
+     * @memberof ParamMgrNode
+     */
+    convertTimeToFrame(time: number): number;
+    /**
+     * convert a frame index to WebAudio time stamp
+     *
+     * @param {number} frame
+     * @returns {number}
+     * @memberof ParamMgrNode
+     */
+    convertFrameToTime(frame: number): number;
+    /**
      * Force to check if an internal param is updated to dispatch immediately value change event if necessary.
      * Note that the event will also be throttled to the automation rate.
      *

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
@@ -1,14 +1,17 @@
 import DisposableAudioWorkletNode from "./DisposableAudioWorkletNode";
+import WebAudioPlugin from "../WebAudioPlugin";
 
 declare interface ParamMgrNode<
         Params extends string = string,
         InternalParams extends string = Params
 > extends DisposableAudioWorkletNode<
         { buffer: { lock: Int32Array, paramsBuffer: Float32Array } },
-        { destroy: true, mapping: ParametersMapping, buffer: true },
+        { destroy: true, paramsMapping: ParametersMapping<Params, InternalParams>, buffer: true },
         Params,
-        { paramsConfig: ParametersDescriptor; mapping: ParametersMapping; internalParamsConfig: InternalParametersDescriptor }
+        { paramsConfig: ParametersDescriptor<Params>; paramsMapping: ParametersMapping<Params, InternalParams>; internalParams: InternalParams[]; instanceId: string; }
 > {
+    plugin: WebAudioPlugin<any, Params, InternalParams>;
+    internalParams: InternalParams[];
     internalParamsConfig: InternalParametersDescriptor<InternalParams>;
     $lock: Int32Array;
     $paramsBuffer: Float32Array;
@@ -50,7 +53,7 @@ declare const ParamMgrNode: {
         context: BaseAudioContext,
         processorId: string,
         parameterData: Record<Params, number>,
-        processorOptions: { paramsConfig: ParametersDescriptor; mapping: ParametersMapping; internalParamsConfig: InternalParametersDescriptor }
+        processorOptions: { paramsConfig: ParametersDescriptor; paramsMapping: ParametersMapping; internalParamsConfig: InternalParametersDescriptor }
     ): ParamMgrNode<Params, InternalParams>;
 }
 export default ParamMgrNode;

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
@@ -46,11 +46,11 @@ declare interface ParamMgrNode<
 }
 declare const ParamMgrNode: {
     prototype: AudioWorkletNode;
-    new <InternalParams extends string = string>(
+    new <Params extends string = string, InternalParams extends string = string>(
         context: BaseAudioContext,
         processorId: string,
         parameterData: Record<Params, number>,
         processorOptions: { paramsConfig: ParametersDescriptor; mapping: ParametersMapping; internalParamsConfig: InternalParametersDescriptor }
-    ): ParamMgrNode<InternalParams>;
+    ): ParamMgrNode<Params, InternalParams>;
 }
 export default ParamMgrNode;

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
@@ -2,7 +2,7 @@ import DisposableAudioWorkletNode from "./DisposableAudioWorkletNode";
 
 declare interface ParamMgrNode<
         Params extends string = string,
-        InternalParams extends string = string
+        InternalParams extends string = Params
 > extends DisposableAudioWorkletNode<
         { buffer: { lock: Int32Array, paramsBuffer: Float32Array } },
         { destroy: true, mapping: ParametersMapping, buffer: true },
@@ -12,11 +12,36 @@ declare interface ParamMgrNode<
     internalParamsConfig: InternalParametersDescriptor<InternalParams>;
     $lock: Int32Array;
     $paramsBuffer: Float32Array;
-    init(): Promise<void>;
-    getParamIndex(key: InternalParams): number;
-    connectParam(key: InternalParams, dest: AudioParam | AudioNode, index?: number): void;
-    disconnectParam(key: InternalParams, dest?: AudioParam | AudioNode, index?: number): void;
-    getParamValue(key: InternalParams): number;
+    $prevParamsBuffer: Float32Array;
+    paramsChangeCanDispatch: Set<InternalParams>;
+    paramsUpdateCheckFnRef: number[];
+    initialize(): Promise<ParamMgrNode>;
+    requestDispatchIParamChange(name: InternalParams): void;
+    getIParamIndex(name: InternalParams): number;
+    connectIParam(name: InternalParams, dest: AudioParam | AudioNode, index?: number): void;
+    disconnectIParam(name: InternalParams, dest?: AudioParam | AudioNode, index?: number): void;
+    getIParamValue(name: InternalParams): number;
+    getIParamsValues(): Record<InternalParams, number>;
+    getParam(name: Params): AudioParam;
+    getParams(): Record<Params, AudioParam>;
+    getParamValue(name: Params): number;
+    setParamValue(name: Params, value: number): void;
+    getParamsValues(): Record<Params, number>;
+    setParamsValues(values: Record<Params, number>): void;
+    getNormalizedParamValue(name: Params): number;
+    setNormalizedParamValue(name: Params, value: number): void;
+    setParamValueAtTime(name: Params, value: number, startTime: number): AudioParam;
+    setNormalizedParamValueAtTime(name: Params, value: number, startTime: number): AudioParam;
+    linearRampToParamValueAtTime(name: Params, value: number, endTime: number): AudioParam;
+    linearRampToNormalizedParamValueAtTime(name: Params, value: number, endTime: number): AudioParam;
+    exponentialRampToParamValueAtTime(name: Params, value: number, endTime: number): AudioParam;
+    exponentialRampToNormalizedParamValueAtTime(name: Params, value: number, endTime: number): AudioParam;
+    setParamTargetAtTime(name: Params, target: number, startTime: number, timeConstant: number): AudioParam;
+    setNormalizedParamTargetAtTime(name: Params, target: number, startTime: number, timeConstant: number): AudioParam;
+    setParamValueCurveAtTime(name: Params, values: Iterable<number> | number[] | Float32Array, startTime: number, duration: number): AudioParam;
+    setNormalizedParamValueCurveAtTime(name: Params, values: Iterable<number> | number[] | Float32Array, startTime: number, duration: number): AudioParam;
+    cancelScheduledParamValues(name: Params, cancelTime: number): AudioParam;
+    cancelAndHoldParamAtTime(name: Params, cancelTime: number): AudioParam;
     destroy(): void;
 }
 declare const ParamMgrNode: {

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.js
@@ -1,12 +1,24 @@
 import DisposableAudioWorkletNode from './DisposableAudioWorkletNode';
 
+const normExp = (x, e) => (e === 0 ? x : x ** (1.5 ** -e));
+const denormExp = (x, e) => (e === 0 ? x : x ** (1.5 ** e));
+const normalize = (x, min, max, e = 0) => (
+	min === 0 && max === 1
+		? normExp(x, e)
+		: normExp((x - min) / (max - min) || 0, e));
+const denormalize = (x, min, max, e = 0) => (
+	min === 0 && max === 1
+		? denormExp(x, e)
+		: denormExp(x, e) * (max - min) + min
+);
+
 /**
  * @typedef {{ destroy: true, mapping: ParametersMapping, buffer: true }} T
  * @typedef {{ buffer: { lock: Int32Array, paramsBuffer: Float32Array } }} F
  * @typedef {{
  * 		paramsConfig: ParametersDescriptor;
  * 		mapping: ParametersMapping;
- * 		internalParamsConfig: InternalParametersDescriptor
+ * 		internalParams: string[]
  * }} O
  */
 /**
@@ -22,30 +34,49 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
      * @param {string} processorId Processor identifier
 	 * @param {Record<string, number>} parameterData parameters initial values map
      * @param {O} processorOptions
+     * @param {import('../WebAudioPlugin').default} plugin the plugin instance
+	 * @param {InternalParametersDescriptor} internalParamsConfig
      * @memberof ParamMgrNode
      */
-	constructor(context, processorId, parameterData, processorOptions) {
+	constructor(context, processorId, parameterData, processorOptions, plugin, internalParamsConfig) {
 		super(context, processorId, {
 			numberOfInputs: 0,
-			numberOfOutputs: Object.keys(processorOptions.internalParamsConfig).length + 1,
+			numberOfOutputs: processorOptions.internalParams.length + 1,
 			parameterData,
 			processorOptions,
 		});
-		this.internalParamsConfig = processorOptions.internalParamsConfig;
+		this.plugin = plugin;
+		this.paramsConfig = processorOptions.paramsConfig;
+		this.internalParams = processorOptions.internalParams;
+		this.internalParamsConfig = internalParamsConfig;
+		this.$prevParamsBuffer = new Float32Array(this.internalParams.length);
+		this.paramsChangeCanDispatch = new Set(this.internalParams);
+		this.paramsUpdateCheckFnRef = [];
 		this.connect(context.destination, 0, 0);
 		this.port.onmessage = (e) => {
 			if (e.data.buffer) {
 				this.$lock = e.data.buffer.lock;
 				this.$paramsBuffer = e.data.buffer.paramsBuffer;
-				if (this.resolve) this.resolve();
+				Object.entries(this.internalParamsConfig).forEach(([name, config], i) => {
+					if (config instanceof AudioParam) {
+						config.value = 0;
+						this.connect(config, i);
+					} else {
+						this.requestDispatchIParamChange(name);
+					}
+				});
+				if (this.resolve) this.resolve(this);
 				this.resolve = undefined;
 			}
 		};
+		this.plugin.on('change:paramsMapping', (mapping) => {
+			this.port.postMessage({ mapping });
+		});
 	}
 
 	resolve = undefined;
 
-	async init() {
+	async initialize() {
 		return new Promise((resolve) => {
 			this.resolve = resolve;
 			this.port.postMessage({ buffer: true });
@@ -53,27 +84,56 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
 	}
 
 	/**
-	 * get the output index of a param
+	 * @param {string} name
+	 * @memberof ParamMgrNode
+	 */
+	requestDispatchIParamChange = (name) => {
+		if (!this.paramsChangeCanDispatch.has(name)) return;
+		const rate = this.internalParamsConfig[name].automationRate;
+		if (typeof rate !== 'number' || !rate) return;
+		const interval = 1000 / rate;
+		const i = this.internalParams.indexOf(name);
+		if (i === -1) return;
+		if (i >= this.internalParams.length) return;
+		if (typeof this.paramsUpdateCheckFnRef[i] === 'number') {
+			window.clearTimeout(this.paramsUpdateCheckFnRef[i]);
+		}
+		this.paramsUpdateCheckFnRef[i] = window.setTimeout(() => {
+			this.paramsUpdateCheckFnRef[i] = undefined;
+			this.paramsChangeCanDispatch.add(name);
+			this.requestDispatchIParamChange(name);
+		}, interval);
+		const prev = this.$prevParamsBuffer[i];
+		const cur = this.$paramsBuffer[i];
+		if (cur !== prev) {
+			this.plugin.emit(`change:internalParam:${name}`, cur, prev);
+			this.$prevParamsBuffer[i] = cur;
+			this.paramsChangeCanDispatch.delete(name);
+		}
+	}
+
+	/**
+	 * get the output index of an internal param
 	 *
-	 * @param {string} key param name
+	 * @param {string} name param name
 	 * @returns {number} output index
 	 * @memberof ParamMgrNode
 	 */
-	getParamIndex(key) {
-		const i = Object.keys(this.internalParamsConfig).indexOf(key);
+	getIParamIndex(name) {
+		const i = this.internalParams.indexOf(name);
 		return i === -1 ? null : i;
 	}
 
 	/**
-	 * Connect a param stream to an AudioParam / AudioNode
+	 * Connect an internal param stream to an AudioParam / AudioNode
 	 *
-	 * @param {string} key param name
+	 * @param {string} name param name
 	 * @param {AudioParam | AudioNode} dest destination AudioParam / AudioNode
 	 * @param {number} index connection index
 	 * @memberof ParamMgrNode
 	 */
-	connectParam(key, dest, index) {
-		const i = this.getParamIndex(key);
+	connectIParam(name, dest, index) {
+		const i = this.getIParamIndex(name);
 		if (i !== null) {
 			if (typeof index === 'number') this.connect(dest, i + 1, index);
 			else this.connect(dest, i + 1);
@@ -81,28 +141,172 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
 	}
 
 	/**
-	 * Disonnect a param stream to an AudioParam / AudioNode
+	 * Disonnect an internal param stream to an AudioParam / AudioNode
 	 *
-	 * @param {string} key param name
+	 * @param {string} name param name
 	 * @param {AudioParam | AudioNode} dest destination AudioParam / AudioNode
 	 * @param {number} index connection index
 	 * @memberof ParamMgrNode
 	 */
-	disconnectParam(key, dest, index) {
-		const i = this.getParamIndex(key);
+	disconnectIParam(name, dest, index) {
+		const i = this.getIParamIndex(name);
 		if (i !== null) {
 			if (typeof index === 'number') this.disconnect(dest, i + 1, index);
 			else this.disconnect(dest, i + 1);
 		}
 	}
 
-	getParamValue(key) {
-		// eslint-disable-next-line no-undef
-		return Atomics.load(this.$paramsBuffer, this.getParamIndex(key));
+	getIParamValue(name) {
+		const i = this.getIParamIndex(name);
+		return i !== null ? this.$paramsBuffer[i] : null;
+	}
+
+	getIParamsValues() {
+		const values = {};
+		this.internalParams.forEach((name, i) => {
+			values[name] = this.$paramsBuffer[i];
+		});
+		return values;
+	}
+
+	getParam(name) {
+		return this.parameters.get(name) || null;
+	}
+
+	getParams() {
+		return Object.fromEntries(this.parameters);
+	}
+
+	getParamValue(name) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		return param.value;
+	}
+
+	setParamValue(name, value) {
+		const param = this.parameters.get(name);
+		if (!param) return;
+		param.value = value;
+	}
+
+	getParamsValues() {
+		const values = {};
+		this.parameters.forEach((v, k) => {
+			values[k] = v.value;
+		});
+		return values;
+	}
+
+	/**
+	 * @param {Record<string, number>} values
+	 */
+	setParamsValues(values) {
+		Object.entries(values).forEach(([k, v]) => {
+			this.setParamValue(k, v);
+		});
+	}
+
+	getNormalizedParamValue(name) {
+		const v = this.getParamValue(name);
+		if (v === null) return null;
+		const { minValue, maxValue, exponent } = this.paramsConfig[name];
+		return normalize(v, minValue, maxValue, exponent);
+	}
+
+	setNormalizedParamValue(name, value) {
+		const param = this.parameters.get(name);
+		if (!param) return;
+		const { minValue, maxValue, exponent } = this.paramsConfig[name];
+		param.value = denormalize(value, minValue, maxValue, exponent);
+	}
+
+	setParamValueAtTime(name, value, startTime) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		return param.setValueAtTime(value, startTime);
+	}
+
+	setNormalizedParamValueAtTime(name, value, startTime) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		const { minValue, maxValue, exponent } = this.paramsConfig[name];
+		return param.setValueAtTime(denormalize(value, minValue, maxValue, exponent), startTime);
+	}
+
+	linearRampToParamValueAtTime(name, value, endTime) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		return param.linearRampToValueAtTime(value, endTime);
+	}
+
+	linearRampToNormalizedParamValueAtTime(name, value, endTime) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		const { minValue, maxValue, exponent } = this.paramsConfig[name];
+		return param.linearRampToValueAtTime(denormalize(value, minValue, maxValue, exponent), endTime);
+	}
+
+	exponentialRampToParamValueAtTime(name, value, endTime) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		return param.exponentialRampToValueAtTime(value, endTime);
+	}
+
+	exponentialRampToNormalizedParamValueAtTime(name, value, endTime) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		const { minValue, maxValue, exponent } = this.paramsConfig[name];
+		return param.exponentialRampToValueAtTime(
+			denormalize(value, minValue, maxValue, exponent), endTime,
+		);
+	}
+
+	setParamTargetAtTime(name, target, startTime, timeConstant) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		return param.setTargetAtTime(target, startTime, timeConstant);
+	}
+
+	setNormalizedParamTargetAtTime(name, target, startTime, timeConstant) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		const { minValue, maxValue, exponent } = this.paramsConfig[name];
+		return param.setTargetAtTime(
+			denormalize(target, minValue, maxValue, exponent), startTime, timeConstant,
+		);
+	}
+
+	setParamValueCurveAtTime(name, values, startTime, duration) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		return param.setValueCurveAtTime(values, startTime, duration);
+	}
+
+	setNormalizedParamValueCurveAtTime(name, valuesIn, startTime, duration) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		const { minValue, maxValue, exponent } = this.paramsConfig[name];
+		const values = Array.from(valuesIn).map((v) => denormalize(v, minValue, maxValue, exponent));
+		return param.setValueCurveAtTime(values, startTime, duration);
+	}
+
+	cancelScheduledParamValues(name, cancelTime) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		return param.cancelScheduledValues(cancelTime);
+	}
+
+	cancelAndHoldParamAtTime(name, cancelTime) {
+		const param = this.parameters.get(name);
+		if (!param) return null;
+		return param.cancelAndHoldAtTime(cancelTime);
 	}
 
 	destroy() {
 		this.disconnect();
+		this.paramsUpdateCheckFnRef.forEach((ref) => {
+			if (typeof ref === 'number') window.clearTimeout(ref);
+		});
 		super.destroy();
 	}
 }

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.js
@@ -29,8 +29,6 @@ const denormalize = (x, min, max, e = 0) => (
  */
 export default class ParamMgrNode extends DisposableAudioWorkletNode {
 	/**
-     * Creates an instance of ParamMgrNode.
-     *
      * @param {BaseAudioContext} context AudioContext
      * @param {string} processorId Processor identifier
 	 * @param {Record<string, number>} parameterData parameters initial values map
@@ -114,11 +112,7 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
 	}
 
 	/**
-	 * get the output index of an internal param
-	 *
-	 * @param {string} name param name
-	 * @returns {number} output index
-	 * @memberof ParamMgrNode
+	 * @param {string} name
 	 */
 	getIParamIndex(name) {
 		const i = this.internalParams.indexOf(name);
@@ -126,11 +120,9 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
 	}
 
 	/**
-	 * Connect an internal param stream to an AudioParam / AudioNode
-	 *
-	 * @param {string} name param name
-	 * @param {AudioParam | AudioNode} dest destination AudioParam / AudioNode
-	 * @param {number} index connection index
+	 * @param {string} name
+	 * @param {AudioParam | AudioNode} dest
+	 * @param {number} index
 	 * @memberof ParamMgrNode
 	 */
 	connectIParam(name, dest, index) {
@@ -142,12 +134,9 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
 	}
 
 	/**
-	 * Disonnect an internal param stream to an AudioParam / AudioNode
-	 *
-	 * @param {string} name param name
-	 * @param {AudioParam | AudioNode} dest destination AudioParam / AudioNode
-	 * @param {number} index connection index
-	 * @memberof ParamMgrNode
+	 * @param {string} name
+	 * @param {AudioParam | AudioNode} dest
+	 * @param {number} index
 	 */
 	disconnectIParam(name, dest, index) {
 		const i = this.getIParamIndex(name);
@@ -219,6 +208,20 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
 		if (!param) return;
 		const { minValue, maxValue, exponent } = this.paramsConfig[name];
 		param.value = denormalize(value, minValue, maxValue, exponent);
+	}
+
+	getNormalizedParamsValues() {
+		const values = {};
+		this.parameters.forEach((v, k) => {
+			values[k] = this.getNormalizedParamValue(k);
+		});
+		return values;
+	}
+
+	setNormalizedParamsValues(values) {
+		Object.entries(values).forEach(([k, v]) => {
+			this.setNormalizedParamValue(k, v);
+		});
 	}
 
 	setParamValueAtTime(name, value, startTime) {

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.js
@@ -13,12 +13,13 @@ const denormalize = (x, min, max, e = 0) => (
 );
 
 /**
- * @typedef {{ destroy: true, mapping: ParametersMapping, buffer: true }} T
+ * @typedef {{ destroy: true, paramsMapping: ParametersMapping, buffer: true }} T
  * @typedef {{ buffer: { lock: Int32Array, paramsBuffer: Float32Array } }} F
  * @typedef {{
  * 		paramsConfig: ParametersDescriptor;
- * 		mapping: ParametersMapping;
- * 		internalParams: string[]
+ * 		paramsMapping: ParametersMapping;
+ * 		internalParams: string[];
+ * 		instanceId: string;
  * }} O
  */
 /**
@@ -69,8 +70,8 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
 				this.resolve = undefined;
 			}
 		};
-		this.plugin.on('change:paramsMapping', (mapping) => {
-			this.port.postMessage({ mapping });
+		this.plugin.on('change:paramsMapping', (paramsMapping) => {
+			this.port.postMessage({ paramsMapping });
 		});
 	}
 

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.js
@@ -60,7 +60,7 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
 				Object.entries(this.internalParamsConfig).forEach(([name, config], i) => {
 					if (config instanceof AudioParam) {
 						config.value = 0;
-						this.connect(config, i);
+						this.connect(config, i + 1);
 					} else {
 						this.requestDispatchIParamChange(name);
 					}

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.js
@@ -1,0 +1,108 @@
+import DisposableAudioWorkletNode from './DisposableAudioWorkletNode';
+
+/**
+ * @typedef {{ destroy: true, mapping: ParametersMapping, buffer: true }} T
+ * @typedef {{ buffer: { lock: Int32Array, paramsBuffer: Float32Array } }} F
+ * @typedef {{
+ * 		paramsConfig: ParametersDescriptor;
+ * 		mapping: ParametersMapping;
+ * 		internalParamsConfig: InternalParametersDescriptor
+ * }} O
+ */
+/**
+ * @export
+ * @class ParamMgrNode
+ * @extends {DisposableAudioWorkletNode<F, T, string, O>}
+ */
+export default class ParamMgrNode extends DisposableAudioWorkletNode {
+	/**
+     * Creates an instance of ParamMgrNode.
+     *
+     * @param {BaseAudioContext} context AudioContext
+     * @param {string} processorId Processor identifier
+	 * @param {Record<string, number>} parameterData parameters initial values map
+     * @param {O} processorOptions
+     * @memberof ParamMgrNode
+     */
+	constructor(context, processorId, parameterData, processorOptions) {
+		super(context, processorId, {
+			numberOfInputs: 0,
+			numberOfOutputs: Object.keys(processorOptions.internalParamsConfig).length + 1,
+			parameterData,
+			processorOptions,
+		});
+		this.internalParamsConfig = processorOptions.internalParamsConfig;
+		this.connect(context.destination, 0, 0);
+		this.port.onmessage = (e) => {
+			if (e.data.buffer) {
+				this.$lock = e.data.buffer.lock;
+				this.$paramsBuffer = e.data.buffer.paramsBuffer;
+				if (this.resolve) this.resolve();
+				this.resolve = undefined;
+			}
+		};
+	}
+
+	resolve = undefined;
+
+	async init() {
+		return new Promise((resolve) => {
+			this.resolve = resolve;
+			this.port.postMessage({ buffer: true });
+		});
+	}
+
+	/**
+	 * get the output index of a param
+	 *
+	 * @param {string} key param name
+	 * @returns {number} output index
+	 * @memberof ParamMgrNode
+	 */
+	getParamIndex(key) {
+		const i = Object.keys(this.internalParamsConfig).indexOf(key);
+		return i === -1 ? null : i;
+	}
+
+	/**
+	 * Connect a param stream to an AudioParam / AudioNode
+	 *
+	 * @param {string} key param name
+	 * @param {AudioParam | AudioNode} dest destination AudioParam / AudioNode
+	 * @param {number} index connection index
+	 * @memberof ParamMgrNode
+	 */
+	connectParam(key, dest, index) {
+		const i = this.getParamIndex(key);
+		if (i !== null) {
+			if (typeof index === 'number') this.connect(dest, i + 1, index);
+			else this.connect(dest, i + 1);
+		}
+	}
+
+	/**
+	 * Disonnect a param stream to an AudioParam / AudioNode
+	 *
+	 * @param {string} key param name
+	 * @param {AudioParam | AudioNode} dest destination AudioParam / AudioNode
+	 * @param {number} index connection index
+	 * @memberof ParamMgrNode
+	 */
+	disconnectParam(key, dest, index) {
+		const i = this.getParamIndex(key);
+		if (i !== null) {
+			if (typeof index === 'number') this.disconnect(dest, i + 1, index);
+			else this.disconnect(dest, i + 1);
+		}
+	}
+
+	getParamValue(key) {
+		// eslint-disable-next-line no-undef
+		return Atomics.load(this.$paramsBuffer, this.getParamIndex(key));
+	}
+
+	destroy() {
+		this.disconnect();
+		super.destroy();
+	}
+}

--- a/packages/sdk/src/ParamMgr/ParamMgrProcessor.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrProcessor.js
@@ -1,0 +1,148 @@
+/* eslint-disable no-plusplus */
+/**
+ * Main function to stringify as a worklet.
+ *
+ * @param {string} processorID processor identifier
+ * @param {ParametersDescriptor} paramsConfig parameterDescriptors
+ */
+const processor = (processorID, paramsConfig) => {
+	const normExp = (x, e) => (e === 0 ? x : x ** (1.5 ** -e));
+	const denormExp = (x, e) => (e === 0 ? x : x ** (1.5 ** e));
+	const normalize = (x, min, max, e = 0) => (
+		min === 0 && max === 1
+			? normExp(x, e)
+			: normExp((x - min) / (max - min) || 0, e));
+	const denormalize = (x, min, max, e = 0) => (
+		min === 0 && max === 1
+			? denormExp(x, e)
+			: denormExp(x, e) * (max - min) + min
+	);
+	const mapValue = (x, eMin, eMax, eExp, sMin, sMax, tMin, tMax) => (
+		denormalize(
+			normalize(
+				normalize(
+					Math.min(sMax, Math.max(sMin, x)),
+					eMin,
+					eMax,
+					eExp,
+				),
+				normalize(sMin, eMin, eMax),
+				normalize(sMax, eMin, eMax),
+			),
+			tMin,
+			tMax,
+		)
+	);
+
+	/**
+	 * @typedef {{ destroy: true, mapping: ParametersMapping, buffer: true }} T
+	 * @typedef {{ buffer: { lock: Int32Array, paramsBuffer: Float32Array } }} F
+	 * @typedef {{
+	 * 		paramsConfig: ParametersDescriptor;
+	 * 		mapping: ParametersMapping;
+	 * 		internalParamsConfig: InternalParametersDescriptor
+	 * }} O
+	 */
+	/**
+	 * `ParamMgrNode`'s `AudioWorkletProcessor`
+	 *
+	 * @class ParamMgrProcessor
+	 * @extends {AudioWorkletProcessor<T, F>}
+	 */
+	class ParamMgrProcessor extends AudioWorkletProcessor {
+		/**
+		 * Here describes plugin external parameters as it is
+		 *
+		 * @readonly
+		 * @static
+		 * @memberof ParamMgrProcessor
+		 */
+		static get parameterDescriptors() {
+			return Object.entries(paramsConfig).map(([name, { defaultValue, minValue, maxValue }]) => ({
+				name,
+				defaultValue,
+				minValue,
+				maxValue,
+			}));
+		}
+
+		/**
+		 * @param {TypedAudioWorkletNodeOptions<O>} options
+		 * @memberof ParamMgrProcessor
+		 */
+		constructor(options) {
+			super(options);
+			this.destroyed = false;
+			const { mapping, internalParamsConfig } = options.processorOptions;
+			this.paramsConfig = paramsConfig;
+			this.mapping = mapping;
+			this.internalParamsConfig = internalParamsConfig;
+			this.internalParamsCount = Object.keys(this.internalParamsConfig).length;
+			this.buffer = new SharedArrayBuffer( // eslint-disable-line no-undef
+				(this.internalParamsCount + 1) * Float32Array.BYTES_PER_ELEMENT,
+			);
+			this.$lock = new Int32Array(this.buffer, 0, 1);
+			this.$paramsBuffer = new Float32Array(this.buffer, 4, this.internalParamsCount);
+			this.port.onmessage = (e) => {
+				if (e.data.destroy) this.destroy();
+				else if (e.data.mapping) this.mapping = e.data.mapping;
+				else if (e.data.buffer) {
+					this.port.postMessage({ buffer: { lock: this.$lock, paramsBuffer: this.$paramsBuffer } });
+				}
+			};
+		}
+
+		lock() {
+			return Atomics.store(this.$lock, 0, 1); // eslint-disable-line no-undef
+		}
+
+		unlock() {
+			return Atomics.store(this.$lock, 0, 0); // eslint-disable-line no-undef
+		}
+
+		/**
+		 * Main process
+		 *
+		 * @param {Float32Array[][]} inputs
+		 * @param {Float32Array[][]} outputs
+		 * @param {Record<string, Float32Array>} parameters
+		 * @memberof ParamMgrProcessor
+		 */
+		process(inputs, outputs, parameters) {
+			if (this.destroyed) return false;
+			this.lock();
+			Object.entries(this.paramsConfig).forEach(([name, { minValue, maxValue, exponent }]) => {
+				if (!this.mapping[name]) return;
+				const raw = parameters[name];
+				Object.entries(this.mapping[name]).forEach(([targetName, targetMapping]) => {
+					const i = Object.keys(this.internalParamsConfig).indexOf(targetName) + 1;
+					if (!i) return;
+					const { sourceRange, targetRange } = targetMapping;
+					const [sMin, sMax] = sourceRange;
+					const [tMin, tMax] = targetRange;
+					let out;
+					if (minValue !== tMin || maxValue !== tMax
+							|| minValue !== sMin || maxValue !== sMax || exponent !== 0) {
+						out = new Float32Array(raw.length);
+						for (let j = 0; j < raw.length; j++) {
+							out[j] = mapValue(raw[j], minValue, maxValue, exponent, sMin, sMax, tMin, tMax);
+						}
+					} else {
+						out = raw;
+					}
+					if (out.length === 1) outputs[i][0].fill(out[0]);
+					else outputs[i][0].set(out);
+					this.$paramsBuffer[i - 1] = out[0]; // eslint-disable-line no-undef, prefer-destructuring
+				});
+			});
+			this.unlock();
+			return true;
+		}
+
+		destroy() {
+			this.destroyed = true;
+		}
+	}
+	registerProcessor(processorID, ParamMgrProcessor);
+};
+export default processor;

--- a/packages/sdk/src/ParamMgr/ParamMgrProcessor.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrProcessor.js
@@ -83,6 +83,7 @@ const processor = (processorId, paramsConfig) => {
 				lock: this.$lock,
 				paramsBuffer: this.$paramsBuffer,
 				outputs: [],
+				frame: undefined,
 			};
 			this.exposed = WebAudioPluginParams[instanceId];
 			this.port.onmessage = (e) => {

--- a/packages/sdk/src/ParamMgr/ParamMgrProcessor.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrProcessor.js
@@ -83,7 +83,6 @@ const processor = (processorId, paramsConfig) => {
 				lock: this.$lock,
 				paramsBuffer: this.$paramsBuffer,
 				outputs: [],
-				frame: currentFrame, // eslint-disable-line no-undef
 			};
 			this.exposed = WebAudioPluginParams[instanceId];
 			this.port.onmessage = (e) => {

--- a/packages/sdk/src/ParamMgr/ParamMgrProcessor.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrProcessor.js
@@ -110,7 +110,7 @@ const processor = (processorId, paramsConfig) => {
 		process(inputs, outputs, parameters) {
 			if (this.destroyed) return false;
 			this.lock();
-			Object.entries(this.paramsConfig).forEach(([name, { minValue, maxValue, exponent }]) => {
+			Object.entries(this.paramsConfig).forEach(([name, { minValue, maxValue }]) => {
 				if (!this.mapping[name]) return;
 				const raw = parameters[name];
 				Object.entries(this.mapping[name]).forEach(([targetName, targetMapping]) => {
@@ -121,10 +121,10 @@ const processor = (processorId, paramsConfig) => {
 					const [tMin, tMax] = targetRange;
 					let out;
 					if (minValue !== tMin || maxValue !== tMax
-							|| minValue !== sMin || maxValue !== sMax || exponent !== 0) {
+							|| minValue !== sMin || maxValue !== sMax) {
 						out = new Float32Array(raw.length);
 						for (let j = 0; j < raw.length; j++) {
-							out[j] = mapValue(raw[j], minValue, maxValue, exponent, sMin, sMax, tMin, tMax);
+							out[j] = mapValue(raw[j], minValue, maxValue, sMin, sMax, tMin, tMax);
 						}
 					} else {
 						out = raw;

--- a/packages/sdk/src/ParamMgr/ParamMgrProcessor.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrProcessor.js
@@ -81,7 +81,9 @@ const processor = (processorId, paramsConfig) => {
 				internalParams,
 				lock: this.$lock,
 				paramsBuffer: this.$paramsBuffer,
+				outputs: [],
 			};
+			this.exposed = WebAudioPluginParams[processorId];
 			this.port.onmessage = (e) => {
 				if (e.data.destroy) this.destroy();
 				else if (e.data.mapping) this.mapping = e.data.mapping;
@@ -131,6 +133,7 @@ const processor = (processorId, paramsConfig) => {
 					}
 					if (out.length === 1) outputs[i][0].fill(out[0]);
 					else outputs[i][0].set(out);
+					this.exposed.outputs[i - 1] = outputs[i][0];
 					this.$paramsBuffer[i - 1] = out[0]; // eslint-disable-line no-undef, prefer-destructuring
 				});
 			});

--- a/packages/sdk/src/ParamMgr/ParamMgrRegister.d.ts
+++ b/packages/sdk/src/ParamMgr/ParamMgrRegister.d.ts
@@ -14,6 +14,6 @@ declare class ParamMgrRegister extends AudioWorkletRegister {
 	 * @returns {Promise<ParamMgrNode>} `ParamMgrNode` instance
 	 * @memberof ParamMgrRegister
 	 */
-	static async getNode<P extends string = string, I extends string = string>(plugin: WebAudioPlugin<any, P, I>, initialParamsValue: Record<P, number>): Promise<ParamMgrNode<P, I>>
+	static getNode<P extends string = string, I extends string = string>(plugin: WebAudioPlugin<any, P, I>, initialParamsValue: Record<P, number>): Promise<ParamMgrNode<P, I>>
 }
 export default ParamMgrRegister;

--- a/packages/sdk/src/ParamMgr/ParamMgrRegister.d.ts
+++ b/packages/sdk/src/ParamMgr/ParamMgrRegister.d.ts
@@ -1,0 +1,19 @@
+import AudioWorkletRegister from './AudioWorkletRegister';
+import ParamMgrNode from './ParamMgrNode';
+import WebAudioPlugin from '../WebAudioPlugin';
+
+declare class ParamMgrRegister extends AudioWorkletRegister {
+	/**
+	 * Get a ParamManager as an AudioWorkletNode instance
+	 *
+	 * @static
+	 * @template P Params
+	 * @template I InternalParams
+     * @param {WebAudioPlugin} plugin the plugin instance
+	 * @param {Record<string, number>} initialParamsValue initial params values
+	 * @returns {Promise<ParamMgrNode>} `ParamMgrNode` instance
+	 * @memberof ParamMgrRegister
+	 */
+	static async getNode<P extends string = string, I extends string = string>(plugin: WebAudioPlugin<any, P, I>, initialParamsValue: Record<P, number>): Promise<ParamMgrNode<P, I>>
+}
+export default ParamMgrRegister;

--- a/packages/sdk/src/ParamMgr/ParamMgrRegister.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrRegister.js
@@ -6,12 +6,16 @@ import processorId from './processorId';
 export default class ParamMgrRegister extends AudioWorkletRegister {
 	static async getNode(plugin, initialParamsValue) {
 		const {
-			audioContext, vendor, name, paramsConfig, paramsMapping, internalParamsConfig,
+			audioContext,
+			pluginId,
+			paramsConfig,
+			paramsMapping,
+			internalParamsConfig,
+			instanceId,
 		} = plugin;
-		const pluginId = vendor + name;
 		await this.register(pluginId + processorId, processor, audioContext.audioWorklet, paramsConfig);
 		const options = {
-			paramsConfig, mapping: paramsMapping, internalParams: Object.keys(internalParamsConfig),
+			paramsConfig, paramsMapping, internalParams: Object.keys(internalParamsConfig), instanceId,
 		};
 		const node = new ParamMgrNode(
 			audioContext, pluginId + processorId, initialParamsValue, options,

--- a/packages/sdk/src/ParamMgr/ParamMgrRegister.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrRegister.js
@@ -4,26 +4,19 @@ import ParamMgrNode from './ParamMgrNode';
 import processorId from './processorId';
 
 export default class ParamMgrRegister extends AudioWorkletRegister {
-	/**
-	 * Get a ParamManager as an AudioWorkletNode instance
-	 *
-	 * @static
-     * @param {string} processorId Processor identifier
-	 * @param {BaseAudioContext} context AudioContext
-	 * @param {Record<string, number>} initialParamsValue parameters initial values map
-	 * @param {ParametersDescriptor} paramsConfig
-	 * @param {ParametersMapping} mapping
-	 * @param {InternalParametersDescriptor} internalParamsConfig
-	 * @returns {Promise<ParamMgrNode>} ParamMgrNode instance
-	 * @memberof ParamMgrRegister
-	 */
-	static async getNode(
-		pluginId, context, initialParamsValue, paramsConfig, mapping, internalParamsConfig,
-	) {
-		await this.register(pluginId + processorId, processor, context.audioWorklet, paramsConfig);
-		const options = { paramsConfig, mapping, internalParamsConfig };
-		const node = new ParamMgrNode(context, pluginId + processorId, initialParamsValue, options);
-		await node.init();
-		return node;
+	static async getNode(plugin, initialParamsValue) {
+		const {
+			audioContext, vendor, name, paramsConfig, paramsMapping, internalParamsConfig,
+		} = plugin;
+		const pluginId = vendor + name;
+		await this.register(pluginId + processorId, processor, audioContext.audioWorklet, paramsConfig);
+		const options = {
+			paramsConfig, mapping: paramsMapping, internalParams: Object.keys(internalParamsConfig),
+		};
+		const node = new ParamMgrNode(
+			audioContext, pluginId + processorId, initialParamsValue, options,
+			plugin, internalParamsConfig,
+		);
+		return node.initialize();
 	}
 }

--- a/packages/sdk/src/ParamMgr/ParamMgrRegister.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrRegister.js
@@ -1,0 +1,29 @@
+import AudioWorkletRegister from './AudioWorkletRegister';
+import processor from './ParamMgrProcessor';
+import ParamMgrNode from './ParamMgrNode';
+import processorId from './processorId';
+
+export default class ParamMgrRegister extends AudioWorkletRegister {
+	/**
+	 * Get a ParamManager as an AudioWorkletNode instance
+	 *
+	 * @static
+     * @param {string} processorId Processor identifier
+	 * @param {BaseAudioContext} context AudioContext
+	 * @param {Record<string, number>} initialParamsValue parameters initial values map
+	 * @param {ParametersDescriptor} paramsConfig
+	 * @param {ParametersMapping} mapping
+	 * @param {InternalParametersDescriptor} internalParamsConfig
+	 * @returns {Promise<ParamMgrNode>} ParamMgrNode instance
+	 * @memberof ParamMgrRegister
+	 */
+	static async getNode(
+		pluginId, context, initialParamsValue, paramsConfig, mapping, internalParamsConfig,
+	) {
+		await this.register(pluginId + processorId, processor, context.audioWorklet, paramsConfig);
+		const options = { paramsConfig, mapping, internalParamsConfig };
+		const node = new ParamMgrNode(context, pluginId + processorId, initialParamsValue, options);
+		await node.init();
+		return node;
+	}
+}

--- a/packages/sdk/src/ParamMgr/processorId.js
+++ b/packages/sdk/src/ParamMgr/processorId.js
@@ -1,0 +1,1 @@
+export default '__WebAudioPlugin_ParamMgr';

--- a/packages/sdk/src/ParamMgr/types.d.ts
+++ b/packages/sdk/src/ParamMgr/types.d.ts
@@ -75,7 +75,8 @@ interface AudioWorkletGlobalScope {
         internalParams: string[];
         lock: Int32Array;
         paramsBuffer: Float32Array;
-        output: Float32Array[];
+        inputs: Float32Array[];
+        outputs: Float32Array[];
         frame: number;
     }>
 }

--- a/packages/sdk/src/ParamMgr/types.d.ts
+++ b/packages/sdk/src/ParamMgr/types.d.ts
@@ -65,3 +65,17 @@ declare class AudioWorkletRegister {
      */
     static register(processorId: string, processor: (id: string, ...injections: any[]) => void, audioWorklet: AudioWorklet, ...injection: any[]): Promise<void>
 }
+interface AudioWorkletGlobalScope {
+    registerProcessor: <T extends AudioWorkletProcessor>(name: string, constructor: AudioWorkletProcessorConstructor<T>) => void;
+    currentFrame: number;
+    currentTime: number;
+    sampleRate: number;
+    AudioWorkletProcessor: AudioWorkletProcessor;
+    WebAudioPluginParams: Record<string, {
+        internalParams: string[];
+        lock: Int32Array;
+        paramsBuffer: Float32Array;
+        output: Float32Array[];
+        frame: number;
+    }>
+}

--- a/packages/sdk/src/ParamMgr/types.d.ts
+++ b/packages/sdk/src/ParamMgr/types.d.ts
@@ -50,3 +50,18 @@ declare const DisposableAudioWorkletNode: {
         O extends any = any
     >(context: BaseAudioContext, name: string, options?: TypedAudioWorkletNodeOptions<O>): DisposableAudioWorkletNode<F, T, P, O>;
 }
+declare class AudioWorkletRegister {
+    /**
+	 * Register a AudioWorklet processor in a closure,
+     * sending to AudioWorkletProcessor with an unique identifier
+     * avoiding double registration
+     *
+     * @param {string} processorId if duplicated, the processor will not be readded.
+     * @param {(id: string, ...injections: any[]) => void} processor a serializable function that contains an AudioWorkletProcessor
+     * with its registration in the AudioWorkletGlobalScope
+     * @param {AudioWorklet} audioWorklet AudioWorklet instance
+     * @param {...any[]} injection this will be serialized and injected to the `processor` function
+     * @returns {Promise<void>} a Promise<void>
+     */
+    static register(processorId: string, processor: (id: string, ...injections: any[]) => void, audioWorklet: AudioWorklet, ...injection: any[]): Promise<void>
+}

--- a/packages/sdk/src/ParamMgr/types.d.ts
+++ b/packages/sdk/src/ParamMgr/types.d.ts
@@ -1,0 +1,52 @@
+interface AudioWorkletAudioParamDescriptor<P extends string = string> extends AudioParamDescriptor {
+    automationRate?: AutomationRate;
+    defaultValue?: number;
+    maxValue?: number;
+    minValue?: number;
+    name: P;
+}
+declare interface AudioWorkletProcessor<T extends Record<string, any> = Record<string, any>, F extends Record<string, any> = Record<string, any>, P extends string = string, O extends any = any> {
+    port: AudioWorkletMessagePort<T, F>;
+    process(inputs: Float32Array[][], outputs: Float32Array[][], parameters: { [key in P]: Float32Array }): boolean;
+}
+declare const AudioWorkletProcessor: {
+    parameterDescriptors(): AudioWorkletAudioParamDescriptor[];
+    new <T extends Record<string, any> = Record<string, any>, F extends Record<string, any> = Record<string, any>, P extends string = string, O extends any = any>(options: TypedAudioWorkletNodeOptions<O>): AudioWorkletProcessor<T, F, P, O>;
+}
+
+interface TypedAudioWorkletNodeOptions<T extends any = any> extends AudioWorkletNodeOptions {
+    processorOptions?: T;
+}
+interface AudioWorkletMessageEvent<T extends any = any> extends MessageEvent {
+    data: T;
+}
+interface AudioWorkletMessagePort<I extends { [key: string]: any } = { [key: string]: any }, O extends { [key: string]: any } = { [key: string]: any }> extends MessagePort {
+    onmessage: ((this: MessagePort, ev: AudioWorkletMessageEvent<I>) => any) | null;
+    onmessageerror: ((this: MessagePort, ev: AudioWorkletMessageEvent<I>) => any) | null;
+    postMessage(message: O, transfer: Transferable[]): void
+    postMessage(message: O, options?: PostMessageOptions): void
+}
+interface DataToProcessor {
+    destroy: true;
+}
+type DisposableAudioParamMap<P extends string = string> = ReadonlyMap<P, AudioParam>;
+declare interface DisposableAudioWorkletNode<
+        F extends Record<string, any> = Record<string, any>,
+        T extends Partial<DataToProcessor> & Record<string, any> = DataToProcessor,
+        P extends string = string,
+        O extends any = any
+> extends AudioWorkletNode {
+    port: AudioWorkletMessagePort<F, T & DataToProcessor>;
+    parameters: DisposableAudioParamMap<P>;
+    readonly options: TypedAudioWorkletNodeOptions<O>;
+    destroyed: boolean;
+    destroy(): void;
+}
+declare const DisposableAudioWorkletNode: {
+    new <
+        F extends Record<string, any> = Record<string, any>,
+        T extends Partial<DataToProcessor> & Record<string, any> = DataToProcessor,
+        P extends string = string,
+        O extends any = any
+    >(context: BaseAudioContext, name: string, options?: TypedAudioWorkletNodeOptions<O>): DisposableAudioWorkletNode<F, T, P, O>;
+}

--- a/packages/sdk/src/WebAudioPlugin.d.ts
+++ b/packages/sdk/src/WebAudioPlugin.d.ts
@@ -25,8 +25,8 @@ export interface TypedEventEmitter<M extends Record<string | symbol, any[]> = {}
  * @interface WebAudioPlugin
  * @extends {(TypedEventEmitter<Events & DefaultEventMap<Params, Patches, Banks>>)}
  * @template Node Custom AudioNode type
- * @template Params Param names, e.g. `"gain" | "feedback" | "ratio"`
- * @template InternalParams Param names, e.g. `"gain" | "feedback" | "ratio"`
+ * @template Params Param names, e.g. `"enabled" | "gain" | "feedback" | "ratio"`
+ * @template InternalParams Param names, e.g. `"gainLeft" | "gainRight"`
  * @template Patches Patch names, e.g. `"patch1" | "patch2"`
  * @template Banks Bank names, e.g. `"bank1" | "bank2"`
  * @template State State type, e.g. `{ id: string, color: string }`
@@ -34,13 +34,13 @@ export interface TypedEventEmitter<M extends Record<string | symbol, any[]> = {}
  */
 interface WebAudioPlugin<
         Node extends AudioNode = AudioNode,
-        Params extends string = string,
-        InternalParams extends string = string,
+        Params extends "enabled" = string,
+        InternalParams extends string = Params,
         Patches extends string = string,
         Banks extends string = string,
         State extends Partial<DefaultState<Params, Patches, Banks>> & Record<string, any> = DefaultState<Params, Patches, Banks>,
         Events extends Partial<DefaultEventMap<Params, Patches, Banks>> & Record<string, any> = DefaultEventMap<Params, Patches, Banks>
-> extends TypedEventEmitter<Events & DefaultEventMap<Params | "enabled", Patches, Banks>> {
+> extends TypedEventEmitter<Events & DefaultEventMap<Params, Patches, Banks>> {
     /**
      * The descriptor will expose the values from `descriptor.json`
      *
@@ -50,33 +50,33 @@ interface WebAudioPlugin<
     readonly descriptor: PluginDescriptor<Params, Patches, Banks>;
     readonly name: string;
     readonly vendor: string;
-    readonly paramsConfig: ParametersDescriptor<Params | "enabled">;
-    readonly internalParamsConfig: InternalParametersDescriptor<InternalParams>;
-    readonly params: Record<Params | "enabled", number>;
-    readonly patches: PatchesDescriptor<Patches, Params | "enabled">;
+    readonly paramsConfig: ParametersDescriptor<Params>;
+    readonly params: Record<Params, number>;
+    readonly patches: PatchesDescriptor<Patches, Params>;
     readonly patch: Patches;
     readonly banks: BanksDescriptor<Banks, Patches>;
     readonly bank: Banks;
     readonly state: State;
     audioContext: BaseAudioContext;
     audioNode: Node;
-    paramMapping: ParametersMapping<Params | "enabled", InternalParams>;
-    paramMgr: ParamMgrNode<Params | "enabled", InternalParams>;
+    internalParamsConfig: InternalParametersDescriptor;
+    paramsMapping: ParametersMapping<Params, InternalParams>;
+    paramMgr: ParamMgrNode<Params, InternalParams>;
     initialized: boolean;
     initialize(options?: Partial<State>): Promise<this>;
     disable(): void;
     enable(): void;
     onBankChange(cb: (e: Banks) => any): this;
     onBankChange(cb: (e: boolean) => any): this;
-    onParamChange(paramName: Params | "enabled", cb: (e: number) => any): this;
-    onParamsChange(cb: (e: Record<Params | "enabled", number>) => any): this;
+    onParamChange(paramName: Params, cb: (e: number) => any): this;
+    onParamsChange(cb: (e: Record<Params, number>) => any): this;
     onPatchChange(cb: (e: Patches) => any): this;
     getState(): State;
     setState(state: Partial<State>): this;
-    getParams(): Record<Params | "enabled", number>;
-    setParams(params: Partial<Record<Params | "enabled", number>>): this;
-    getParam(paramName: Params | "enabled"): number;
-    setParam(paramName: Params | "enabled", paramValue: number): this;
+    getParams(): Record<Params, number>;
+    setParams(params: Partial<Record<Params, number>>): this;
+    getParam(paramName: Params): number;
+    setParam(paramName: Params, paramValue: number): this;
     getPatch(): Patches;
     setPatch(patch: Patches): this;
     getBank(): Banks;

--- a/packages/sdk/src/WebAudioPlugin.d.ts
+++ b/packages/sdk/src/WebAudioPlugin.d.ts
@@ -64,6 +64,7 @@ export interface DefaultEventMap<
     "change:bank": Banks;
     "change": Partial<State>;
     "destroy": never;
+    string: number;
 }
 /**
  * `WebAudioPlugin` main interface
@@ -87,20 +88,29 @@ interface WebAudioPlugin<
 > extends TypedEventEmitter<Events> {
     readonly descriptor: PluginDescriptor<Params, Patches, Banks>;
     readonly name: string;
-    readonly params: ParametersDescriptor<Params>;
+    readonly paramsConfig: ParametersDescriptor<Params>;
+    readonly params: Record<Params, number>;
     readonly patches: PatchesDescriptor<Patches, Params>;
+    readonly patch: Patches;
     readonly banks: BanksDescriptor<Banks, Patches>;
+    readonly bank: Banks;
     readonly state: State;
     audioContext: BaseAudioContext;
-    _audioNode: Node;
+    private _audioNode: Node;
     audioNode: Node;
     initialized: boolean;
-    readonly ready: this;
-    initialize(): Promise<this>;
+    initialize(options?: CreateOptions): Promise<this>;
+	onBankChange(cb: (e: Banks) => any): this;
+	onBankChange(cb: (e: boolean) => any): this;
+	onParamChange(paramName: Params, cb: (e: number) => any): this;
+	onParamsChange(cb: (e: Record<Params, number>) => any): this;
+	onPatchChange(cb: (e: Patches) => any): this;
     getState(): State;
     setState(state: Partial<State>): this;
     getParams(): Record<Params, number>;
     setParams(params: Partial<Record<Params, number>>): this;
+    getParam(paramName: Params): number;
+    setParam(paramName: Params, paramValue: number): this;
     getPatch(): Patches;
     setPatch(patch: Patches): this;
     getBank(): Banks;
@@ -121,7 +131,7 @@ declare const WebAudioPlugin: {
         Banks extends string = never,
         State extends Partial<DefaultState<Params, Patches, Banks>> & Record<string, any> = DefaultState<Params, Patches, Banks>,
         Events extends Partial<DefaultEventMap<Params, Patches, Banks, State>> & Record<string, any> = DefaultEventMap<Params, Patches, Banks, State>
-    >(audioContext: AudioContext, options?: CreateOptions<State>): WebAudioPlugin<Node, Params, Patches, Banks, State, Events>;
+    >(audioContext: AudioContext): WebAudioPlugin<Node, Params, Patches, Banks, State, Events>;
 };
 
 export default WebAudioPlugin;

--- a/packages/sdk/src/WebAudioPlugin.d.ts
+++ b/packages/sdk/src/WebAudioPlugin.d.ts
@@ -57,6 +57,8 @@ interface WebAudioPlugin<
     readonly banks: BanksDescriptor<Banks, Patches>;
     readonly bank: Banks;
     readonly state: State;
+    readonly instanceId: string;
+    readonly pluginId: string;
     audioContext: BaseAudioContext;
     audioNode: Node;
     internalParamsConfig: InternalParametersDescriptor;

--- a/packages/sdk/src/WebAudioPlugin.d.ts
+++ b/packages/sdk/src/WebAudioPlugin.d.ts
@@ -34,7 +34,7 @@ export interface TypedEventEmitter<M extends Record<string | symbol, any[]> = {}
  */
 interface WebAudioPlugin<
         Node extends AudioNode = AudioNode,
-        Params extends "enabled" = string,
+        Params extends string = string,
         InternalParams extends string = Params,
         Patches extends string = string,
         Banks extends string = string,
@@ -89,7 +89,7 @@ declare const WebAudioPlugin: {
     prototype: WebAudioPlugin;
     descriptor: PluginDescriptor;
     guiModuleUrl: string;
-    createInstance(audioContext: AudioContext, options?: Partail<State>): Promise<WebAudioPlugin>;
+    createInstance(audioContext: AudioContext, options?: Partial<DefaultState> & Record<string, any>): Promise<WebAudioPlugin>;
     new <
         Node extends AudioNode = AudioNode,
         Params extends string = string,

--- a/packages/sdk/src/WebAudioPlugin.js
+++ b/packages/sdk/src/WebAudioPlugin.js
@@ -30,6 +30,8 @@ export default class WebAudioPlugin extends EventEmitter {
 	get vendor() { return this.descriptor.vendor; }
 	get banks() { return this.descriptor.banks || {}; }
 	get patches() { return this.descriptor.patches || {}; }
+	get pluginId() { return this.vendor + this.name; }
+	instanceId = this.pluginId + performance.now();
 	/**
 	 * @type {ParametersDescriptor}
 	 */
@@ -77,6 +79,7 @@ export default class WebAudioPlugin extends EventEmitter {
 			}, {});
 	}
 	set internalParamsConfig(config) {
+		if (this._internalParamsConfig) throw new Error('internalParamsConfig can be set only once.');
 		this._internalParamsConfig = config;
 	}
 

--- a/packages/sdk/src/WebAudioPlugin.js
+++ b/packages/sdk/src/WebAudioPlugin.js
@@ -62,17 +62,29 @@ export default class WebAudioPlugin extends EventEmitter {
 	 * @type {InternalParametersDescriptor}
 	 */
 	get internalParamsConfig() {
+		const { paramsConfig } = this;
 		if (!this._internalParamsConfig) {
-			return Object.entries(this.paramsConfig).reduce((configs, [name, { minValue, maxValue }]) => {
-				configs[name] = { minValue, maxValue, automationRate: 30 };
-				return configs;
-			}, {});
+			return Object.entries(paramsConfig)
+				.reduce((configs, [name, { minValue, maxValue, defaultValue }]) => {
+					configs[name] = {
+						minValue, maxValue, defaultValue, automationRate: 30,
+					};
+					return configs;
+				}, {});
 		}
 		return Object.entries(this._internalParamsConfig || {})
 			.reduce((configs, [name, config]) => {
 				if (config instanceof AudioParam) configs[name] = config;
 				else {
-					const defaultConfig = { minValue: 0, maxValue: 1, automationRate: 30 };
+					const minValue = paramsConfig[name] ? paramsConfig[name].minValue : 0;
+					const maxValue = paramsConfig[name] ? paramsConfig[name].maxValue : 1;
+					const defaultValue = paramsConfig[name] ? paramsConfig[name].defaultValue : 0;
+					const defaultConfig = {
+						minValue,
+						maxValue,
+						defaultValue,
+						automationRate: 30,
+					};
 					configs[name] = { ...defaultConfig, ...config };
 				}
 				return configs;

--- a/packages/sdk/src/WebAudioPlugin.js
+++ b/packages/sdk/src/WebAudioPlugin.js
@@ -52,7 +52,7 @@ export default class WebAudioPlugin extends EventEmitter {
 	}
 
 	// Initial state of the plugin
-	enabled = false;
+	enabled = true;
 	params = {};
 	patch = undefined;
 	bank = undefined;

--- a/packages/sdk/src/WebAudioPlugin.js
+++ b/packages/sdk/src/WebAudioPlugin.js
@@ -83,37 +83,6 @@ export default class WebAudioPlugin extends EventEmitter {
 		this._internalParamsConfig = config;
 	}
 
-	initialized = false;
-
-	// EventEmitter is synchronous:
-	// https://nodejs.org/api/events.html#events_asynchronous_vs_synchronous
-	onBankChange(cb) { return this.on('change:bank', cb); }
-	onEnabledChange(cb) { return this.on('change:enabled', cb); }
-	onParamChange(paramName, cb) { return this.on(`change:param:${paramName}`, cb); }
-	onParamsChange(cb) { return this.on('change:params', cb); }
-	onPatchChange(cb) { return this.on('change:patch', cb); }
-
-	// The audioNode of the plugin
-	// The host must connect to this input
-	_audioNode = undefined;
-	get audioNode() {
-		if (!this.initialized) console.warn('plugin should be initialized before getting the audionode');
-		return this._audioNode;
-	}
-	set audioNode(node) {
-		this._audioNode = node;
-	}
-
-	// Initial state of the plugin
-	get enabled() {
-		return this.paramMgr ? !!this.paramMgr.getParamValue('enabled') : true;
-	}
-	set enabled(enabled) {
-		this.setParam('enabled', +enabled);
-	}
-	get params() {
-		return this.paramMgr.getParamsValues();
-	}
 	_paramsMapping = {}
 	/**
 	 * @type {ParametersMapping}
@@ -145,6 +114,38 @@ export default class WebAudioPlugin extends EventEmitter {
 		const previousMapping = this.paramsMapping;
 		this._paramsMapping = mapping;
 		this.emit('change:paramsMapping', this.paramsMapping, previousMapping);
+	}
+
+	initialized = false;
+
+	// EventEmitter is synchronous:
+	// https://nodejs.org/api/events.html#events_asynchronous_vs_synchronous
+	onBankChange(cb) { return this.on('change:bank', cb); }
+	onEnabledChange(cb) { return this.on('change:enabled', cb); }
+	onParamChange(paramName, cb) { return this.on(`change:param:${paramName}`, cb); }
+	onParamsChange(cb) { return this.on('change:params', cb); }
+	onPatchChange(cb) { return this.on('change:patch', cb); }
+
+	// The audioNode of the plugin
+	// The host must connect to this input
+	_audioNode = undefined;
+	get audioNode() {
+		if (!this.initialized) console.warn('plugin should be initialized before getting the audionode');
+		return this._audioNode;
+	}
+	set audioNode(node) {
+		this._audioNode = node;
+	}
+
+	// Initial state of the plugin
+	get enabled() {
+		return this.paramMgr ? !!this.paramMgr.getParamValue('enabled') : true;
+	}
+	set enabled(enabled) {
+		this.setParam('enabled', +enabled);
+	}
+	get params() {
+		return this.paramMgr.getParamsValues();
 	}
 	patch = undefined;
 	bank = undefined;

--- a/packages/sdk/src/test.js
+++ b/packages/sdk/src/test.js
@@ -1,0 +1,8 @@
+import WebAudioPlugin from './WebAudioPlugin';
+
+/**
+ * @type {WebAudioPlugin<AudioNode, "a">}
+ */
+const p = new WebAudioPlugin();
+const param = p.paramsConfig.a;
+if (param.type === 'enum') param.values

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -1,0 +1,103 @@
+type TParameterType = "boolean" | "float" | "int";
+interface ParameterDescriptor {
+    /**
+     * `"float"` by default
+     *
+     * @type {TParameterType}
+     * @memberof ParameterDescriptor
+     */
+    type?: TParameterType;
+    /**
+     * `0` by default
+     *
+     * @type {number}
+     * @memberof ParameterDescriptor
+     */
+    defaultValue?: number;
+    /**
+     * `0` by default
+     *
+     * @type {number}
+     * @memberof ParameterDescriptor
+     */
+    minValue?: number;
+    /**
+     * `1` by default
+     *
+     * @type {number}
+     * @memberof ParameterDescriptor
+     */
+    maxValue?: number;
+    /**
+     * `0` by default (linear)
+     *
+     * @type {number}
+     * @memberof ParameterDescriptor
+     */
+    exponent?: number;
+}
+type ParametersDescriptor<Params extends string = string> = Record<Params, ParameterDescriptor>;
+interface InternalParameterDescriptor {
+    /**
+     * `true` by default
+     *
+     * @type {boolean}
+     * @memberof InternalParameterDescriptor
+     */
+    isAudioParam?: boolean;
+}
+type InternalParametersDescriptor<InternalParams extends string = string> = Record<InternalParams, InternalParameterDescriptor>;
+interface ParameterMappingTarget {
+    /**
+     * Source param's `[minValue, maxValue]` by default
+     *
+     * @type {[number, number]}
+     * @memberof ParameterMappingTarget
+     */
+    sourceRange?: [number, number];
+    /**
+     * Source param's `[minValue, maxValue]` by default
+     *
+     * @type {[number, number]}
+     * @memberof ParameterMappingTarget
+     */
+    targetRange?: [number, number];
+}
+type ParametersMapping<Params extends string = string, InternalParams extends string = string> = Record<Params, Record<InternalParams, ParameterMappingTarget>>;
+interface PatchDescriptor<Params extends string = string> {
+    label: string;
+    params: Partial<Record<Params, number>>;
+}
+type PatchesDescriptor<Patches extends string = string, Params extends string = string> = Record<Patches, PatchDescriptor<Params>>;
+interface BankDescriptor<Patches extends string = string> {
+    label: string;
+    patches: Patches[];
+}
+type BanksDescriptor<Banks extends string = string, Patches extends string = string> = Record<Banks, BankDescriptor<Patches>>;
+interface PluginDescriptor<Params extends string = string, Patches extends string = string, Banks extends string = string> {
+    name: string;
+    author: string;
+    vendor: string;
+    version: string;
+    entry: string;
+    gui: string | "none";
+    url: string;
+    params?: ParametersDescriptor<Params>;
+    patches?: PatchesDescriptor<Patches, Params>;
+    banks?: BanksDescriptor<Banks, Patches>;
+    [key: string]: any;
+}
+interface DefaultState<Params extends string = string, Patches extends string = string, Banks extends string = string> {
+    enabled: boolean;
+    params: Partial<Record<Params, number>>;
+    patch: Patches;
+    bank: Banks;
+}
+interface DefaultEventMap<Params extends string = string, Patches extends string = string, Banks extends string = string> {
+    "change:enabled": [boolean, boolean];
+    "change:params": [Partial<Record<Params, number>>, Partial<Record<Params, number>>, Partial<Record<Params, number>>];
+    "change:patch": [Patches, Patches];
+    "change:bank": [Banks, Banks];
+    "destroy": [];
+    string: [number, number];
+}

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -60,7 +60,7 @@ interface InternalParameterDescriptor {
      */
     automationRate?: number;
 }
-type InternalParametersDescriptor<InternalParams extends string = string> = Record<InternalParams, AudioParam | InternalParameterDescriptor>;
+type InternalParametersDescriptor<InternalParams extends string = string> = Record<InternalParams, AudioParam | AudioNode | InternalParameterDescriptor>;
 interface ParameterMappingTarget {
     /**
      * Source param's `[minValue, maxValue]` by default

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -44,6 +44,13 @@ interface InternalParameterDescriptor {
      * @type {number}
      * @memberof InternalParameterDescriptor
      */
+    defaultValue?: number;
+    /**
+     * `0` by default
+     *
+     * @type {number}
+     * @memberof InternalParameterDescriptor
+     */
     minValue?: number;
     /**
      * `1` by default
@@ -59,6 +66,13 @@ interface InternalParameterDescriptor {
      * @memberof InternalParameterDescriptor
      */
     automationRate?: number;
+    /**
+     * The default event listener,
+     * the event will be fired when the param get changed
+     *
+     * @memberof InternalParameterDescriptor
+     */
+    onChange?: (value: number, previousValue: number) => any;
 }
 type InternalParametersDescriptor<InternalParams extends string = string> = Record<InternalParams, AudioParam | AudioNode | InternalParameterDescriptor>;
 interface ParameterMappingTarget {
@@ -107,12 +121,14 @@ interface DefaultState<Params extends string = string, Patches extends string = 
     patch: Patches;
     bank: Banks;
 }
+type AudioParamMethodNames = keyof Omit<AudioParam, "minValue" | "maxValue" | "automationRate" | "defaultValue" | "value">;
 interface DefaultEventMap<Params extends string = string, Patches extends string = string, Banks extends string = string> {
     "change:enabled": [boolean, boolean];
     "change:params": [Partial<Record<Params, number>>, Partial<Record<Params, number>>, Partial<Record<Params, number>>];
     "change:patch": [Patches, Patches];
     "change:bank": [Banks, Banks];
     "destroy": [];
-    "change:paramsMapping": [ParametersMapping, ParametersMapping]
+    "change:paramsMapping": [ParametersMapping, ParametersMapping];
+    "automation": [AudioParamMethodNames | "value", Params, ...any[]];
     string: [number, number];
 }

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -39,14 +39,28 @@ interface ParameterDescriptor {
 type ParametersDescriptor<Params extends string = string> = Record<Params, ParameterDescriptor>;
 interface InternalParameterDescriptor {
     /**
-     * `true` by default
+     * `0` by default
      *
-     * @type {boolean}
+     * @type {number}
      * @memberof InternalParameterDescriptor
      */
-    isAudioParam?: boolean;
+    minValue?: number;
+    /**
+     * `1` by default
+     *
+     * @type {number}
+     * @memberof InternalParameterDescriptor
+     */
+    maxValue?: number;
+    /**
+     * `30` (1/30s for each change check) by default
+     *
+     * @type {number}
+     * @memberof InternalParameterDescriptor
+     */
+    automationRate?: number;
 }
-type InternalParametersDescriptor<InternalParams extends string = string> = Record<InternalParams, InternalParameterDescriptor>;
+type InternalParametersDescriptor<InternalParams extends string = string> = Record<InternalParams, AudioParam | InternalParameterDescriptor>;
 interface ParameterMappingTarget {
     /**
      * Source param's `[minValue, maxValue]` by default
@@ -99,5 +113,6 @@ interface DefaultEventMap<Params extends string = string, Patches extends string
     "change:patch": [Patches, Patches];
     "change:bank": [Banks, Banks];
     "destroy": [];
+    "change:paramsMapping": [ParametersMapping, ParametersMapping]
     string: [number, number];
 }


### PR DESCRIPTION
The parameter manager `paramMgr` handles a mapping between exposed automatable parameters and internal parameters that can be `AudioParam`s or not, using an `AudioWorklet` processor.
While creating the `AudioNode` via `createAudioNode()`, `internalParamsConfig` and `paramsMapping` can be declared using their setter.

- `internalParamsConfig` decribes the plugin's internal parameters and whether they are `AudioParam` or not.
If it is, the `AudioParam` will be automatically controlled by the manager.
If not, an `automationRate` and be set in order to listen to parameter changes events that can be fired at the defined rate maximum. The event name is `change:internalParam:${paramName}`. If a `onChange` field is defined with a function in the config, the function will become the default listener.
If the `internalParamsConfig` remains `undefined`, it will be the same as the exposed parameters `paramsConfig`.

- `paramsMapping` describes the relation between exposed automatable parameters and internal parameters, as one automatable parameter should be able to control multiple internal parameters at the same time.
A value mapping can be set via `sourceRange` and `targetRange`. The incoming value of the automatable parameter will be firstly clipped using `sourceRange`, then the value in the `sourceRange` will be remapped to the `targetRange`. If these fields remain `undefined`, they will be the same as the `minValue` and the `maxValue` of the exposed parameter.
If one parameter name appears in both `paramsConfig` and `internalParamsConfig`, the mapping will be created automatically if it is not declared explicitly in the `paramsMapping`.
Dynamically change the `paramsMapping` is possible using the setter. 

I added an optional field `exponent` in the `paramsConfig` to be able to set the parameter values using a normalized value between 0 and 1 with an exponent factor. It is 0 (linear) by default.
To use the automations, `AudioParam` methods with their normalized version are available via the parameter manager.

For WAM developers, @owengc and @jariseon, they may want to update sample-accurate values in their own way. So I added `automation` events while host is scheduling automation or change values with the parameter manager. The events can be listened like `plugin.on('automation', (methodType, paramName, time) => {});` There are also methods provided for converting between frame and time.

the `PingpongDelay` is now working using this new design pattern, the display knobs are updated from the plugin using `requestAnimationFrame` with the exposed parameters' `AudioParam`, They emit changes to the plugin using the parameters manager, These changes will be sent directly to internal `AudioParam`s, or to the event handlers.

The automation part is **not fully tested** yet.

About the implementation, the AudioWorkletProcessor sends back to the main thread a SharedArrayBuffer with two views.
- `$paramsBuffer`: this contains one value per buffer aka `k-rate` values of each internal parameters. the order is known in `internalParams` array.
- `$lock`: will be set to 1 when the processor is writing new values to the `$paramsBuffer`
They are also accessible in the `AudioWorkletGloablScope`.

full parameters buffers and a framestamp are also available under the AudioWorkletGloablScope, by getting `globalThis.WebAudioPluginParams[instanceId]`, the `instanceId` is in the plugin instance.