### PR TITLE
A layer for AudioParam inside ParamMgr

### DIFF
--- a/packages/docs/ParameterManager.md
+++ b/packages/docs/ParameterManager.md
@@ -122,3 +122,52 @@ All `AudioParam` methods are exposed in the Parameter Manager with their normali
 
 ### Need to go deeper?
 Sample-accurate *internal parameters* and *exposed parameters* values, with a frame stamp, are accessible in the `AudioWorkletGlobalScope`. The developer can get them by getting `globalThis.WebAudioPluginParams[instanceId]`, the instance identifier `instanceId` is unique to each `WebAudioPlugin` instance. See [AudioWorkletGlobalScope](https://github.com/53js/webaudioplugin/blob/master/packages/sdk/src/ParamMgr/types.d.ts).
+
+### Use a Plugin from a Host
+
+A host usually deals with exposed parameters of a plugin, set or get the values instantly or schedule automations. These operations are available using the parameter manager.
+
+For example, to get the values / normalized values of all the exposed parameters:
+
+```JavaScript
+const values = plugin.paramMgr.getParamsValues();
+const normalizedValues = plugin.paramMgr.getNormalizedParamsValues();
+```
+
+It is possible to manipulate parameters with their AudioParam instance:
+
+```JavaScript
+let audioParam;
+const audioParamsMap = plugin.paramMgr.getParams();
+audioParam = audioParamsMap["mix"];
+// or
+audioParam = plugin.paramMgr.getParam("mix");
+// or
+audioParam = plugin.paramMgr.parameters.get("mix");
+```
+
+The AudioParam got is an extended version of native one, having all the normalized version of native methods, emitting the `automation` events.
+
+```JavaScript
+audioParam.value = 0.5;
+audioParam.normalizedValue = 0.5;
+```
+Methods:
+```TypeScript
+interface MgrAudioParam extends AudioParam {
+    normalize(value: number): number;
+    denormalize(value: number): number;
+    cancelAndHoldAtTime(cancelTime: number): MgrAudioParam;
+    cancelScheduledValues(cancelTime: number): MgrAudioParam;
+    exponentialRampToValueAtTime(value: number, endTime: number): MgrAudioParam;
+    exponentialRampToNormalizedValueAtTime(value: number, endTime: number): MgrAudioParam;
+    linearRampToValueAtTime(value: number, endTime: number): MgrAudioParam;
+    linearRampToNormalizedValueAtTime(value: number, endTime: number): MgrAudioParam;
+    setTargetAtTime(target: number, startTime: number, timeConstant: number): MgrAudioParam;
+    setNormalizedTargetAtTime(target: number, startTime: number, timeConstant: number): MgrAudioParam;
+    setValueAtTime(value: number, startTime: number): MgrAudioParam;
+    setNormalizedValueAtTime(valueIn: string, startTime: number): MgrAudioParam;
+    setValueCurveAtTime(values: number[] | Float32Array | Iterable<number>, startTime: number, duration: number): MgrAudioParam;
+    setNormalizedValueCurveAtTime(values: number[] | Float32Array | Iterable<number>, startTime: number, duration: number): MgrAudioParam;
+}
+```

--- a/packages/sdk/rollup.config.js
+++ b/packages/sdk/rollup.config.js
@@ -3,7 +3,6 @@ import babel from 'rollup-plugin-babel';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import builtins from 'rollup-plugin-node-builtins';
-import { terser } from 'rollup-plugin-terser';
 
 export default {
 	input: './src',
@@ -27,6 +26,5 @@ export default {
 			browser: true,
 		}),
 		commonjs(),
-		terser(),
 	],
 };

--- a/packages/sdk/src/Loader.js
+++ b/packages/sdk/src/Loader.js
@@ -21,12 +21,12 @@ export const loadPluginFromDescriptor = async (descriptor, optionsIn) => {
 	} = descriptor;
 	const entryModuleUrl = new URL(entry, url);
 	const guiModuleUrl = gui === 'none' ? undefined : new URL(gui, url);
-	const { default: PluginClass } = await import(entryModuleUrl);
+	const { default: PluginClass } = await import(/* webpackIgnore: true */entryModuleUrl);
 
 	const options = { ...defaultLoadOptions, ...optionsIn };
 	// if gui wanted, we load it right now
 	// if not wanted, the gui will be loaded when calling plugin.createGui()
-	if (!options.noGui && guiModuleUrl) { await import(guiModuleUrl); }
+	if (!options.noGui && guiModuleUrl) { await import(/* webpackIgnore: true */guiModuleUrl); }
 
 	/**
 	 * Extends Plugin with actual descriptor and gui module url

--- a/packages/sdk/src/ParamMgr/MgrAudioParam.d.ts
+++ b/packages/sdk/src/ParamMgr/MgrAudioParam.d.ts
@@ -1,0 +1,71 @@
+import { TypedEventEmitter } from '../WebAudioPlugin';
+
+/**
+ * Extended `AudioParam` for normalized value support and event emissions.
+ *
+ * @interface MgrAudioParam
+ * @extends {AudioParam}
+ */
+declare interface MgrAudioParam extends AudioParam {
+    /**
+     * The event emitter for automation events
+     *
+     * @type {TypedEventEmitter}
+     * @memberof MgrAudioParam
+     */
+    emitter: TypedEventEmitter;
+    /**
+     * the parameter name
+     *
+     * @type {string}
+     * @memberof MgrAudioParam
+     */
+    name: string;
+    /**
+     * exponent factor declared in `descriptor.json`
+     *
+     * @type {number}
+     * @memberof MgrAudioParam
+     */
+    exponent: number;
+    /**
+     * normalize value following current max/max/exponent
+     *
+     * @returns {number}
+     * @memberof MgrAudioParam
+     */
+    normalize(): number;
+    /**
+     * denormalize value following current max/max/exponent
+     *
+     * @returns {number}
+     * @memberof MgrAudioParam
+     */
+    denormalize(): number;
+    /**
+     * normalized current param value
+     *
+     * @type {number}
+     * @memberof MgrAudioParam
+     */
+    normalizedValue: number;
+    // normalized version of methods
+    cancelAndHoldAtTime(cancelTime: number): MgrAudioParam;
+    cancelScheduledValues(cancelTime: number): MgrAudioParam;
+    exponentialRampToValueAtTime(value: number, endTime: number): MgrAudioParam;
+    exponentialRampToNormalizedValueAtTime(value: number, endTime: number): MgrAudioParam;
+    linearRampToValueAtTime(value: number, endTime: number): MgrAudioParam;
+    linearRampToNormalizedValueAtTime(value: number, endTime: number): MgrAudioParam;
+    setTargetAtTime(target: number, startTime: number, timeConstant: number): MgrAudioParam;
+    setNormalizedTargetAtTime(target: number, startTime: number, timeConstant: number): MgrAudioParam;
+    setValueAtTime(value: number, startTime: number): MgrAudioParam;
+    setNormalizedValueAtTime(valueIn: string, startTime: number): MgrAudioParam;
+    setValueCurveAtTime(values: number[] | Float32Array | Iterable<number>, startTime: number, duration: number): MgrAudioParam;
+    setNormalizedValueCurveAtTime(values: number[] | Float32Array | Iterable<number>, startTime: number, duration: number): MgrAudioParam;
+}
+
+declare const MgrAudioParam: {
+    prototype: MgrAudioParam;
+}
+
+export default MgrAudioParam;

--- a/packages/sdk/src/ParamMgr/MgrAudioParam.d.ts
+++ b/packages/sdk/src/ParamMgr/MgrAudioParam.d.ts
@@ -31,17 +31,19 @@ declare interface MgrAudioParam extends AudioParam {
     /**
      * normalize value following current max/max/exponent
      *
+     * @param {number} value
      * @returns {number}
      * @memberof MgrAudioParam
      */
-    normalize(): number;
+    normalize(value: number): number;
     /**
      * denormalize value following current max/max/exponent
      *
+     * @param {number} value
      * @returns {number}
      * @memberof MgrAudioParam
      */
-    denormalize(): number;
+    denormalize(value: number): number;
     /**
      * normalized current param value
      *

--- a/packages/sdk/src/ParamMgr/MgrAudioParam.js
+++ b/packages/sdk/src/ParamMgr/MgrAudioParam.js
@@ -1,0 +1,106 @@
+const normExp = (x, e) => (e === 0 ? x : x ** (1.5 ** -e));
+const denormExp = (x, e) => (e === 0 ? x : x ** (1.5 ** e));
+const normalize = (x, min, max, e = 0) => (
+	min === 0 && max === 1
+		? normExp(x, e)
+		: normExp((x - min) / (max - min) || 0, e));
+const denormalize = (x, min, max, e = 0) => (
+	min === 0 && max === 1
+		? denormExp(x, e)
+		: denormExp(x, e) * (max - min) + min
+);
+
+export default class MgrAudioParam extends AudioParam {
+	emitter = undefined;
+
+	name = undefined;
+
+	exponent = 0;
+
+	normalize(value) {
+		const { minValue, maxValue, exponent } = this;
+		return normalize(value, minValue, maxValue, exponent);
+	}
+
+	denormalize(value) {
+		const { minValue, maxValue, exponent } = this;
+		return denormalize(value, minValue, maxValue, exponent);
+	}
+
+	set value(value) {
+		super.value = value;
+		if (this.emitter) this.emitter.emit('automation', 'value', this.name, value);
+	}
+
+	get value() {
+		return super.value;
+	}
+
+	set normalizedValue(valueIn) {
+		this.value = this.normalize(valueIn);
+	}
+
+	get normalizedValue() {
+		return this.normalize(this.value);
+	}
+
+	setValueAtTime(value, startTime) {
+		if (this.emitter) this.emitter.emit('automation', 'setValueAtTime', this.name, value, startTime);
+		return super.setValueAtTime(value, startTime);
+	}
+
+	setNormalizedValueAtTime(valueIn, startTime) {
+		const value = this.denormalize(valueIn);
+		return this.setValueAtTime(value, startTime);
+	}
+
+	linearRampToValueAtTime(value, endTime) {
+		if (this.emitter) this.emitter.emit('automation', 'linearRampToValueAtTime', this.name, value, endTime);
+		return super.linearRampToValueAtTime(value, endTime);
+	}
+
+	linearRampToNormalizedValueAtTime(valueIn, endTime) {
+		const value = this.denormalize(valueIn);
+		return this.linearRampToValueAtTime(value, endTime);
+	}
+
+	exponentialRampToValueAtTime(value, endTime) {
+		if (this.emitter) this.emitter.emit('automation', 'exponentialRampToValueAtTime', this.name, value, endTime);
+		return super.exponentialRampToValueAtTime(value, endTime);
+	}
+
+	exponentialRampToNormalizedValueAtTime(valueIn, endTime) {
+		const value = this.denormalize(valueIn);
+		return this.exponentialRampToValueAtTime(value, endTime);
+	}
+
+	setTargetAtTime(target, startTime, timeConstant) {
+		if (this.emitter) this.emitter.emit('automation', 'setTargetAtTime', this.name, target, startTime, timeConstant);
+		return super.setTargetAtTime(target, startTime, timeConstant);
+	}
+
+	setNormalizedTargetAtTime(targetIn, startTime, timeConstant) {
+		const target = this.denormalize(targetIn);
+		return this.setTargetAtTime(target, startTime, timeConstant);
+	}
+
+	setValueCurveAtTime(values, startTime, duration) {
+		if (this.emitter) this.emitter.emit('automation', 'setValueCurveAtTime', this.name, values, startTime, duration);
+		return super.setValueCurveAtTime(values, startTime, duration);
+	}
+
+	setNormalizedValueCurveAtTime(valuesIn, startTime, duration) {
+		const values = Array.from(valuesIn).map((v) => this.denormalize(v));
+		return this.setValueCurveAtTime(values, startTime, duration);
+	}
+
+	cancelScheduledParamValues(cancelTime) {
+		if (this.emitter) this.emitter.emit('automation', 'cancelScheduledValues', this.name, cancelTime);
+		return super.cancelScheduledValues(cancelTime);
+	}
+
+	cancelAndHoldParamAtTime(cancelTime) {
+		if (this.emitter) this.emitter.emit('automation', 'cancelAndHoldAtTime', this.name, cancelTime);
+		return super.cancelAndHoldAtTime(cancelTime);
+	}
+}

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
@@ -258,7 +258,7 @@ declare interface ParamMgrNode<
     destroy(): void;
 }
 declare const ParamMgrNode: {
-    prototype: AudioWorkletNode;
+    prototype: ParamMgrNode;
 	/**
      * Creates an instance of ParamMgrNode.
      *

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
@@ -210,10 +210,10 @@ declare interface ParamMgrNode<
     /**
      * set the current value of every exposed parameters
      *
-     * @param {Record<Params, number>} values
+     * @param {Partial<Record<Params, number>>} values
      * @memberof ParamMgrNode
      */
-    setParamsValues(values: Record<Params, number>): void;
+    setParamsValues(values: Partial<Record<Params, number>>): void;
     /**
      * normalized value version of `getParamValue()`
      *
@@ -233,10 +233,10 @@ declare interface ParamMgrNode<
     /**
      * normalized value version of `getParamsValues()`
      *
-     * @returns {Record<Params, number>}
+     * @returns {Partial<Record<Params, number>>}
      * @memberof ParamMgrNode
      */
-    getNormalizedParamsValues(): Record<Params, number>;
+    getNormalizedParamsValues(): Partial<Record<Params, number>>;
     /**
      * normalized value version of `setParamsValues()`
      *

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.d.ts
@@ -26,6 +26,13 @@ declare interface ParamMgrNode<
      */
     plugin: WebAudioPlugin<any, Params, InternalParams>;
     /**
+     * The state of the initialization.
+     *
+     * @type {boolean}
+     * @memberof ParamMgrNode
+     */
+    initialized: boolean;
+    /**
      * An array that contains ordered internal params names.
      * The order is important for the output connections and for the parameters' values buffer
      *

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.js
@@ -7,6 +7,7 @@ import MgrAudioParam from './MgrAudioParam';
  * @typedef {{
  * 		paramsConfig: ParametersDescriptor;
  * 		paramsMapping: ParametersMapping;
+ * 		internalParamsMinValues: number[];
  * 		internalParams: string[];
  * 		instanceId: string;
  * }} O
@@ -55,8 +56,12 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
 				Object.entries(this.internalParamsConfig).forEach(([name, config], i) => {
 					if (this.context.state === 'suspended') this.$paramsBuffer[i] = config.defaultValue;
 					if (config instanceof AudioParam || config instanceof AudioNode) {
-						config.value = 0;
-						this.connect(config, i + 1);
+						try {
+							config.automationRate = 'a-rate';
+						} finally {
+							config.value = Math.max(0, config.minValue);
+							this.connect(config, i + 1);
+						}
 					} else {
 						if (config.onChange) this.plugin.on(`change:internalParam:${name}`, config.onChange);
 						this.requestDispatchIParamChange(name);

--- a/packages/sdk/src/ParamMgr/ParamMgrNode.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrNode.js
@@ -51,6 +51,7 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
 			if (e.data.buffer) {
 				this.$lock = e.data.buffer.lock;
 				this.$paramsBuffer = e.data.buffer.paramsBuffer;
+				if (this.initialized) return;
 				Object.entries(this.internalParamsConfig).forEach(([name, config], i) => {
 					if (this.context.state === 'suspended') this.$paramsBuffer[i] = config.defaultValue;
 					if (config instanceof AudioParam || config instanceof AudioNode) {
@@ -63,6 +64,7 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
 				});
 				if (this.resolve) this.resolve(this);
 				this.resolve = undefined;
+				this.initialized = true;
 			}
 		};
 		this.plugin.on('change:paramsMapping', (paramsMapping) => {
@@ -71,6 +73,8 @@ export default class ParamMgrNode extends DisposableAudioWorkletNode {
 	}
 
 	resolve = undefined;
+
+	initialized = false;
 
 	async initialize() {
 		return new Promise((resolve) => {

--- a/packages/sdk/src/ParamMgr/ParamMgrRegister.js
+++ b/packages/sdk/src/ParamMgr/ParamMgrRegister.js
@@ -15,7 +15,12 @@ export default class ParamMgrRegister extends AudioWorkletRegister {
 		} = plugin;
 		await this.register(pluginId + processorId, processor, audioContext.audioWorklet, paramsConfig);
 		const options = {
-			paramsConfig, paramsMapping, internalParams: Object.keys(internalParamsConfig), instanceId,
+			paramsConfig,
+			paramsMapping,
+			internalParamsMinValues: Object.values(internalParamsConfig)
+				.map((config) => Math.max(0, config?.minValue || 0)),
+			internalParams: Object.keys(internalParamsConfig),
+			instanceId,
 		};
 		const node = new ParamMgrNode(
 			audioContext, pluginId + processorId, initialParamsValue, options,

--- a/packages/sdk/src/WebAudioPlugin.d.ts
+++ b/packages/sdk/src/WebAudioPlugin.d.ts
@@ -190,6 +190,7 @@ interface WebAudioPlugin<
      * @memberof WebAudioPlugin
      */
     initialize(options?: Partial<State>): Promise<this>;
+    destroy(): void;
     disable(): void;
     enable(): void;
     onBankChange(cb: (e: Banks) => any): this;

--- a/packages/sdk/src/WebAudioPlugin.js
+++ b/packages/sdk/src/WebAudioPlugin.js
@@ -331,7 +331,7 @@ export default class WebAudioPlugin extends EventEmitter {
 	 */
 	async loadGui() {
 		if (!this.constructor.guiModuleUrl) throw new TypeError('Gui module not found');
-		return import(this.constructor.guiModuleUrl);
+		return import(/* webpackIgnore: true */this.constructor.guiModuleUrl);
 	}
 
 	async createGui(options) {

--- a/packages/sdk/src/index.d.ts
+++ b/packages/sdk/src/index.d.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
-import WebAudioPlugin from "../src/WebAudioPlugin";
-import CompositeAudioNode from "../src/CompositeAudioNode";
-import Loader from "../src/Loader";
+import WebAudioPlugin from "./WebAudioPlugin";
+import CompositeAudioNode from "./CompositeAudioNode";
+import * as Loader from "./Loader";
 
-export * from "../src/WebAudioPlugin";
+export * from "./WebAudioPlugin";
 export { WebAudioPlugin, CompositeAudioNode, Loader };

--- a/packages/sdk/src/test.js
+++ b/packages/sdk/src/test.js
@@ -1,8 +1,0 @@
-import WebAudioPlugin from './WebAudioPlugin';
-
-/**
- * @type {WebAudioPlugin<AudioNode, "a">}
- */
-const p = new WebAudioPlugin();
-const param = p.paramsConfig.a;
-if (param.type === 'enum') param.values


### PR DESCRIPTION
This pull request added:
1. a layer that extends `AudioParam` from the `ParamMgr`. In case that the host need to manipulate directly the `AudioParam` from `ParamMgr.parameters` Map, its methods will have same side effects as calling the methods from the `ParamMgr`.

For example, the following will be possible and emit `automation` event at the same time.
```JavaScript
plugin.paramMgr.parameters.get("gain").setNormalizedValueAtTime(0.5, currentTime + 1);
```
2. a fallback to `ArrayBuffer` if `SharedArrayBuffer` is not supported to browser in the `ParamMgr`. (use to check internal parameters value changes)