### PR TITLE
remove params from json, derive from internal, remove enabled

### DIFF
--- a/packages/faustPingPongDelay/plugin/Gui/Gui.js
+++ b/packages/faustPingPongDelay/plugin/Gui/Gui.js
@@ -354,14 +354,9 @@ export default class PingPongDelayFaustGui extends HTMLElement {
 	}
 
     handleAnimationFrame = () => {
-		const {
-			feedback,
-			time,
-			mix
-        } = this._plug.params;
-        this._root.getElementById('/PingPongDelayFaust/feedback').value = feedback ;
-		this._root.getElementById('/PingPongDelayFaust/time').value = time ;
-		this._root.getElementById('/PingPongDelayFaust/mix').value = mix ;
+        this._root.getElementById('/PingPongDelayFaust/feedback').value = this._plug.params['/PingPongDelayFaust/feedback'];
+		this._root.getElementById('/PingPongDelayFaust/time').value = this._plug.params['/PingPongDelayFaust/time'];
+		this._root.getElementById('/PingPongDelayFaust/mix').value = this._plug.params['/PingPongDelayFaust/mix'];
 		window.requestAnimationFrame(this.handleAnimationFrame);
     }
     
@@ -388,19 +383,19 @@ export default class PingPongDelayFaustGui extends HTMLElement {
 			.getElementById('/PingPongDelayFaust/feedback')
 			.addEventListener('input', (e) =>
 				this._plug.setParam(
-					'feedback',
+					'/PingPongDelayFaust/feedback',
 					e.target.value
 				)
 			);
 		this._root
 			.getElementById('/PingPongDelayFaust/mix')
 			.addEventListener('input', (e) =>
-				this._plug.setParam('mix', e.target.value)
+				this._plug.setParam('/PingPongDelayFaust/mix', e.target.value)
 			);
 		this._root
 			.getElementById('/PingPongDelayFaust/time')
 			.addEventListener('input', (e) =>
-				this._plug.setParam('time', e.target.value)
+				this._plug.setParam('/PingPongDelayFaust/time', e.target.value)
 			);
 	}
 
@@ -411,7 +406,7 @@ export default class PingPongDelayFaustGui extends HTMLElement {
 			.getElementById('/PingPongDelayFaust/bypass')
 			.addEventListener('change', (e) =>
 				this._plug.setParam(
-					'enabled',
+					'/PingPongDelayFaust/bypass',
 					1 - e.target.value
 				)
 			);

--- a/packages/faustPingPongDelay/plugin/descriptor.json
+++ b/packages/faustPingPongDelay/plugin/descriptor.json
@@ -1,22 +1,5 @@
 {
 	"name": "FaustPingPongDelay",
-	"params": {
-		"time": {
-			"defaultValue": 0.3,
-			"minValue": 0.1,
-			"maxValue": 1
-		},
-		"feedback": {
-			"defaultValue": 0.3,
-			"minValue": 0,
-			"maxValue": 1
-		},
-		"mix": {
-			"defaultValue": 0.6,
-			"minValue": 0,
-			"maxValue": 1
-		}
-	},
 	"banks": {
 		"bank1": {
 			"label": "Bank 1",

--- a/packages/faustPingPongDelay/plugin/index.js
+++ b/packages/faustPingPongDelay/plugin/index.js
@@ -24,18 +24,7 @@ export default class FaustPingPongDelayPlugin extends WebAudioPlugin {
 	async createAudioNode(options) {
 		const baseURL = getBasetUrl(this.descriptor.url);
 		const factory = new PluginFactory(this.audioContext, baseURL);
-		let node = await factory.load();
-
-		// Note that the "exposed param names" will be the property names, not the 
-		// names passed in the get(...). These exposed params will be used in the GUI code
-		// and in the descriptor.json code.
-		this.internalParamsConfig = {
-            mix: node.parameters.get('/PingPongDelayFaust/mix'),
-            feedback: node.parameters.get('/PingPongDelayFaust/feedback'),
-			time: node.parameters.get('/PingPongDelayFaust/time'),
-			enabled: node.parameters.get('/PingPongDelayFaust/bypass')
-        };
-		
+		const node = await factory.load();
 		return node;
 	}
 }

--- a/packages/livegain/src/LiveGainPlugin.tsx
+++ b/packages/livegain/src/LiveGainPlugin.tsx
@@ -8,6 +8,48 @@ export class LiveGainPlugin extends WebAudioPlugin<LiveGainNode, Parameters, Par
     async createAudioNode() {
         const node = new LiveGainNode(this.audioContext, { plugin: this });
         await node.setup();
+        this.paramsConfig = {
+            gain: {
+                defaultValue: 0,
+                minValue: -70,
+                maxValue: 6
+            },
+            frameRate: {
+                defaultValue: 60,
+                minValue: 0,
+                maxValue: 60
+            },
+            speedLim: {
+                defaultValue: 16,
+                minValue: 0,
+                maxValue: 60
+            },
+            min: {
+                defaultValue: -70,
+                minValue: -70,
+                maxValue: -6
+            },
+            max: {
+                defaultValue: 6,
+                minValue: 0,
+                maxValue: 15
+            },
+            step: {
+                defaultValue: 0.01,
+                minValue: 0.01,
+                maxValue: 6
+            },
+            orientation: {
+                defaultValue: 0,
+                minValue: 0,
+                maxValue: 1
+            },
+            metering: {
+                defaultValue: 0,
+                minValue: 0,
+                maxValue: 1
+            }
+        };
         this.internalParamsConfig = {
             gain: { onChange: node.handleGainChanged },
             frameRate: {},

--- a/packages/livegain/src/descriptor.json
+++ b/packages/livegain/src/descriptor.json
@@ -1,47 +1,5 @@
 {
 	"name": "LiveGain",
-	"params": {
-		"gain": {
-			"defaultValue": 0,
-			"minValue": -70,
-			"maxValue": 6
-		},
-		"frameRate": {
-			"defaultValue": 60,
-			"minValue": 0,
-			"maxValue": 60
-		},
-		"speedLim": {
-			"defaultValue": 16,
-			"minValue": 0,
-			"maxValue": 60
-		},
-		"min": {
-			"defaultValue": -70,
-			"minValue": -70,
-			"maxValue": -6
-		},
-		"max": {
-			"defaultValue": 6,
-			"minValue": 0,
-			"maxValue": 15
-		},
-		"step": {
-			"defaultValue": 0.01,
-			"minValue": 0.01,
-			"maxValue": 6
-		},
-		"orientation": {
-			"defaultValue": 0,
-			"minValue": 0,
-			"maxValue": 1
-		},
-		"metering": {
-			"defaultValue": 0,
-			"minValue": 0,
-			"maxValue": 1
-		}
-	},
 	"banks": {
 		"bank1": {
 			"label": "Bank 1",

--- a/packages/pingpongdelay/src/Gui/Gui.js
+++ b/packages/pingpongdelay/src/Gui/Gui.js
@@ -74,8 +74,7 @@ export default class PingPongDelayHTMLElement extends HTMLElement {
 		this.shadowRoot
 			.querySelector('#switch1')
 			.addEventListener('change', function onChange() {
-				if (this.checked) plugin.enable();
-				else plugin.disable();
+				plugin.paramMgr.setParamValue('enabled', +!!this.checked);
 			});
 	}
 

--- a/packages/pingpongdelay/src/descriptor.json
+++ b/packages/pingpongdelay/src/descriptor.json
@@ -1,16 +1,5 @@
 {
 	"name": "PingPongDelay",
-	"params": {
-		"feedback": {
-			"defaultValue": 0.5
-		},
-		"time": {
-			"defaultValue": 0.5
-		},
-		"mix": {
-			"defaultValue": 0.5
-		}
-	},
 	"banks": {
 		"bank1": {
 			"label": "Bank 1",

--- a/packages/pingpongdelay/src/index.js
+++ b/packages/pingpongdelay/src/index.js
@@ -25,6 +25,20 @@ export default class PingPongDelayPlugin extends WebAudioPlugin {
 	async createAudioNode(options) {
 		const pingPongDelayNode = new PingPongDelayNode(this.audioContext, options);
 
+		this.paramsConfig = {
+			feedback: {
+				defaultValue: 0.5,
+			},
+			time: {
+				defaultValue: 0.5,
+			},
+			mix: {
+				defaultValue: 0.5,
+			},
+			enabled: {
+				defaultValue: 1,
+			},
+		};
 		this.internalParamsConfig = {
 			delayLeftTime: pingPongDelayNode.delayNodeLeft.delayTime,
 			delayRightTime: pingPongDelayNode.delayNodeRight.delayTime,

--- a/packages/quadrafuzz/src/Gui/Gui.js
+++ b/packages/quadrafuzz/src/Gui/Gui.js
@@ -101,13 +101,12 @@ export default class QuadrafuzzHTMLElement extends HTMLElement {
 		console.log("Quadrafuzz : set switch listener");
 		const { plugin } = this;
 		// by default, plugin is disabled
-		plugin.disable();
+		plugin.setParams({ enabled: 0 });
 
 		this.shadowRoot
 			.querySelector('#switch1')
 			.addEventListener('change', function onChange() {
-				if (this.checked) plugin.enable();
-				else plugin.disable();
+				plugin.setParams({ enabled: +!!this.checked });
 			});
 	}
 

--- a/packages/quadrafuzz/src/descriptor.json
+++ b/packages/quadrafuzz/src/descriptor.json
@@ -1,27 +1,5 @@
 {
 	"name": "Quadrafuzz",
-	"params": {
-		"lowGain": {
-			"defaultValue": 0.6,
-			"minValue": 0,
-			"maxValue": 1
-		},
-		"midLowGain": {
-			"defaultValue": 0.8,
-			"minValue": 0,
-			"maxValue": 1
-		},
-		"midHighGain": {
-			"defaultValue": 0.5,
-			"minValue": 0,
-			"maxValue": 1
-		},
-		"highGain": {
-			"defaultValue": 0.5,
-			"minValue": 0,
-			"maxValue": 1
-		}
-	},
 	"banks": {
 		"bank1": {
 			"label": "Bank 1",

--- a/packages/quadrafuzz/src/index.js
+++ b/packages/quadrafuzz/src/index.js
@@ -16,6 +16,33 @@ export default class QuadrafuzzPlugin extends WebAudioPlugin {
 	async createAudioNode(options) {
 		const quadrafuzzNode = new QuadrafuzzNode(this.audioContext, options);
 
+		this.paramsConfig = {
+			lowGain: {
+				defaultValue: 0.6,
+				minValue: 0,
+				maxValue: 1,
+			},
+			midLowGain: {
+				defaultValue: 0.8,
+				minValue: 0,
+				maxValue: 1,
+			},
+			midHighGain: {
+				defaultValue: 0.5,
+				minValue: 0,
+				maxValue: 1,
+			},
+			highGain: {
+				defaultValue: 0.5,
+				minValue: 0,
+				maxValue: 1,
+			},
+			enabled: {
+				defaultValue: 1,
+				minValue: 0,
+				maxValue: 1,
+			},
+		};
 
 		this.internalParamsConfig = {
 			// quadrafuzzNode.overdrives[0] is a waveshaper. When we call setLowGain(value) it will change

--- a/packages/quadrafuzz_without_builder/src/Gui/Gui.js
+++ b/packages/quadrafuzz_without_builder/src/Gui/Gui.js
@@ -259,13 +259,12 @@ export default class QuadrafuzzHTMLElement extends HTMLElement {
 		console.log("Quadrafuzz : set switch listener");
 		const { plugin } = this;
 		// by default, plugin is disabled
-		plugin.disable();
+		plugin.setParams({ enabled: 0 });
 
 		this.shadowRoot
 			.querySelector('#switch1')
 			.addEventListener('change', function onChange() {
-				if (this.checked) plugin.enable();
-				else plugin.disable();
+				plugin.setParams({ enabled: +!!this.checked });
 			});
 	}
 

--- a/packages/quadrafuzz_without_builder/src/descriptor.json
+++ b/packages/quadrafuzz_without_builder/src/descriptor.json
@@ -1,27 +1,5 @@
 {
 	"name": "Quadrafuzz",
-	"params": {
-		"lowGain": {
-			"defaultValue": 0.6,
-			"minValue": 0,
-			"maxValue": 1
-		},
-		"midLowGain": {
-			"defaultValue": 0.8,
-			"minValue": 0,
-			"maxValue": 1
-		},
-		"midHighGain": {
-			"defaultValue": 0.5,
-			"minValue": 0,
-			"maxValue": 1
-		},
-		"highGain": {
-			"defaultValue": 0.5,
-			"minValue": 0,
-			"maxValue": 1
-		}
-	},
 	"banks": {
 		"bank1": {
 			"label": "Bank 1",

--- a/packages/quadrafuzz_without_builder/src/index.js
+++ b/packages/quadrafuzz_without_builder/src/index.js
@@ -16,6 +16,33 @@ export default class QuadrafuzzPlugin extends WebAudioPlugin {
 	async createAudioNode(options) {
 		const quadrafuzzNode = new QuadrafuzzNode(this.audioContext, options);
 
+		this.paramsConfig = {
+			lowGain: {
+				defaultValue: 0.6,
+				minValue: 0,
+				maxValue: 1,
+			},
+			midLowGain: {
+				defaultValue: 0.8,
+				minValue: 0,
+				maxValue: 1,
+			},
+			midHighGain: {
+				defaultValue: 0.5,
+				minValue: 0,
+				maxValue: 1,
+			},
+			highGain: {
+				defaultValue: 0.5,
+				minValue: 0,
+				maxValue: 1,
+			},
+			enabled: {
+				defaultValue: 1,
+				minValue: 0,
+				maxValue: 1,
+			},
+		};
 
 		this.internalParamsConfig = {
 			// quadrafuzzNode.overdrives[0] is a waveshaper. When we call setLowGain(value) it will change

--- a/packages/sdk/src/WebAudioPlugin.d.ts
+++ b/packages/sdk/src/WebAudioPlugin.d.ts
@@ -63,15 +63,6 @@ interface WebAudioPlugin<
      */
     readonly vendor: string;
     /**
-     * retrieved from the descriptor, the exposed-params' descriptor with full information
-     * 
-     * There will be a `enabled` param in any case.
-     *
-     * @type {ParametersDescriptor<Params>}
-     * @memberof WebAudioPlugin
-     */
-    readonly paramsConfig: ParametersDescriptor<Params>;
-    /**
      * getter of the exposed-params' values
      *
      * @type {Record<Params, number>}
@@ -142,13 +133,22 @@ interface WebAudioPlugin<
      */
     audioNode: Node;
     /**
+     * the exposed-params' descriptor with full information
+     * 
+     * If not explicitly set, it will be derived from the internal paramters `internalParamsConfig`
+     * 
+     * can be set only once
+     *
+     * @type {ParametersDescriptor<Params>}
+     * @memberof WebAudioPlugin
+     */
+    paramsConfig: ParametersDescriptor<Params>;
+    /**
      * the description of the plugin's internal parameters
      * 
      * is an `AudioParam` or not. if not, the update rate can be provided (`30` by default)
      * 
      * can be set only once
-     * 
-     * If not explicitly set, it will be derived from the exposed paramters `paramsConfig`
      *
      * @type {InternalParametersDescriptor<InternalParams>}
      * @memberof WebAudioPlugin

--- a/packages/sdk/src/types.d.ts
+++ b/packages/sdk/src/types.d.ts
@@ -110,14 +110,12 @@ interface PluginDescriptor<Params extends string = string, Patches extends strin
     entry: string;
     gui: string | "none";
     url: string;
-    params?: ParametersDescriptor<Params>;
     patches?: PatchesDescriptor<Patches, Params>;
     banks?: BanksDescriptor<Banks, Patches>;
     [key: string]: any;
 }
 interface DefaultState<Params extends string = string, Patches extends string = string, Banks extends string = string> {
     enabled: boolean;
-    params: Partial<Record<Params, number>>;
     patch: Patches;
     bank: Banks;
 }


### PR DESCRIPTION
The exposed parameters no longer need to be declared in the `descriptor.json`, if needed, it can be set via `paramsConfig` setter while setting `internalParamsConfig`. You can leave it unset, which means it will be the same as the `internalParamsConfig`.
The `enabled` property and related methods are removed.