### PR TITLE
Bug fix: register ParamMgr processor on other AudioContext

### DIFF
--- a/packages/sdk/src/ParamMgr/AudioWorkletRegister.d.ts
+++ b/packages/sdk/src/ParamMgr/AudioWorkletRegister.d.ts
@@ -1,5 +1,5 @@
 /// <reference path="types.d.ts" />
 
-export const registeredProcessors: Set<string>;
-export const registeringProcessors: Set<string>;
+export const registeredProcessors: Map<AudioWorklet, Set<string>>;
+export const registeringProcessors: Map<AudioWorklet, Set<string>>;
 export default AudioWorkletRegister;

--- a/packages/sdk/src/ParamMgr/AudioWorkletRegister.d.ts
+++ b/packages/sdk/src/ParamMgr/AudioWorkletRegister.d.ts
@@ -1,5 +1,5 @@
 /// <reference path="types.d.ts" />
 
-export const registeredProcessors: Map<AudioWorklet, Set<string>>;
-export const registeringProcessors: Map<AudioWorklet, Set<string>>;
+export const registeredProcessors: WeakMap<AudioWorklet, Set<string>>;
+export const registeringProcessors: WeakMap<AudioWorklet, Set<string>>;
 export default AudioWorkletRegister;

--- a/packages/sdk/src/ParamMgr/AudioWorkletRegister.js
+++ b/packages/sdk/src/ParamMgr/AudioWorkletRegister.js
@@ -1,5 +1,5 @@
-export const registeredProcessors = new Map();
-export const registeringProcessors = new Map();
+export const registeredProcessors = new WeakMap();
+export const registeringProcessors = new WeakMap();
 
 export default class AudioWorkletRegister {
 	static registeredProcessors = registeredProcessors;

--- a/packages/sdk/src/WebAudioPlugin.d.ts
+++ b/packages/sdk/src/WebAudioPlugin.d.ts
@@ -233,7 +233,7 @@ declare const WebAudioPlugin: {
     prototype: WebAudioPlugin;
     descriptor: PluginDescriptor;
     guiModuleUrl: string;
-    createInstance(audioContext: AudioContext, options?: Partial<DefaultState> & Record<string, any>): Promise<WebAudioPlugin>;
+    createInstance(audioContext: BaseAudioContext, options?: Partial<DefaultState> & Record<string, any>): Promise<WebAudioPlugin>;
     new <
         Node extends AudioNode = AudioNode,
         Params extends string = string,
@@ -242,7 +242,7 @@ declare const WebAudioPlugin: {
         Banks extends string = string,
         State extends Partial<DefaultState<Params, Patches, Banks>> & Record<string, any> = DefaultState<Params, Patches, Banks>,
         Events extends Partial<DefaultEventMap<Params, Patches, Banks>> & Record<string, any> = DefaultEventMap<Params, Patches, Banks>
-    >(audioContext: AudioContext): WebAudioPlugin<Node, Params, InternalParams, Patches, Banks, State, Events>;
+    >(audioContext: BaseAudioContext): WebAudioPlugin<Node, Params, InternalParams, Patches, Banks, State, Events>;
 };
 
 export default WebAudioPlugin;


### PR DESCRIPTION
Encountered this issue when rendering effects on an `OfflineAudioContext`. Using the `AudioWorkletRegister`, a registered `AudioWorklet` should supposed to be re-registerable on another `AudioContext`. So here's the fix, the registered logger is now a `WeakMap<AudioWorklet, Set<string>>`.